### PR TITLE
Add Shona (sn) language support

### DIFF
--- a/num2words/__init__.py
+++ b/num2words/__init__.py
@@ -25,8 +25,9 @@ from . import (lang_AM, lang_AR, lang_AZ, lang_BE, lang_BN, lang_CA, lang_CE,
                lang_HY, lang_ID, lang_IS, lang_IT, lang_JA, lang_KN, lang_KO,
                lang_KZ, lang_LT, lang_LV, lang_MN, lang_NL, lang_NO, lang_PL,
                lang_PT, lang_PT_BR, lang_RO, lang_RU, lang_SK, lang_SL,
-               lang_SR, lang_SV, lang_TE, lang_TET, lang_TG, lang_TH, lang_TR,
-               lang_UK, lang_VI, lang_ZH, lang_ZH_CN, lang_ZH_HK, lang_ZH_TW)
+               lang_SN, lang_SR, lang_SV, lang_TE, lang_TET, lang_TG, lang_TH,
+               lang_TR, lang_UK, lang_VI, lang_ZH, lang_ZH_CN, lang_ZH_HK,
+               lang_ZH_TW)
 
 CONVERTER_CLASSES = {
     'am': lang_AM.Num2Word_AM(),
@@ -79,6 +80,7 @@ CONVERTER_CLASSES = {
     'ru': lang_RU.Num2Word_RU(),
     'sk': lang_SK.Num2Word_SK(),
     'sl': lang_SL.Num2Word_SL(),
+    'sn': lang_SN.Num2Word_SN(),
     'sr': lang_SR.Num2Word_SR(),
     'sv': lang_SV.Num2Word_SV(),
     'te': lang_TE.Num2Word_TE(),

--- a/num2words/lang_SN.py
+++ b/num2words/lang_SN.py
@@ -1,0 +1,369 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2003, Taro Ogawa.  All Rights Reserved.
+# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
+"""
+Module for converting numbers to words in Shona (chiShona).
+Shona is a Bantu language spoken in Zimbabwe and Mozambique.
+"""
+
+from __future__ import unicode_literals
+
+from .base import Num2Word_Base
+from .utils import get_digits, splitbyx
+
+class Num2Word_SN(Num2Word_Base):
+    """Convert numbers to Shona words."""
+    
+    CURRENCY_FORMS = {
+        'USD': (
+            ('dhora', 'madhora'), ('sendi', 'masendi')
+        ),
+        'ZWL': (
+            ('dhora', 'madhora'), ('sendi', 'masendi')
+        ),
+        'ZAR': (
+            ('randi', 'marandi'), ('sendi', 'masendi')
+        ),
+    }
+
+    def __init__(self):
+        # Basic numbers 0-10
+        self.ones = {
+            0: 'zero',
+            1: 'motsi',
+            2: 'piri',
+            3: 'tatu',
+            4: 'china',
+            5: 'shanu',
+            6: 'tanhatu',
+            7: 'nomwe',
+            8: 'sere',
+            9: 'pfumbamwe',
+            10: 'gumi'
+        }
+        
+        # Numbers for tens when used in compound forms
+        self.tens_forms = {
+            2: 'maviri',
+            3: 'matatu',
+            4: 'mana',
+            5: 'mashanu',
+            6: 'matanhatu',
+            7: 'manomwe',
+            8: 'masere',
+            9: 'mapfumbamwe'
+        }
+        
+        # Ordinal numbers
+        self.ordinals = {
+            1: 'wekutanga',
+            2: 'wechipiri',
+            3: 'wechitatu',
+            4: 'wechina',
+            5: 'wechishanu',
+            6: 'wechitanhatu',
+            7: 'wechinomwe',
+            8: 'wechisere',
+            9: 'wechipfumbamwe',
+            10: 'wegumi'
+        }
+        
+        # Large number scales
+        self.scale = {
+            100: 'zana',
+            1000: 'churu',
+            1000000: 'miriyoni',
+            1000000000: 'bhiriyoni',
+            1000000000000: 'tiriyoni'
+        }
+        
+        super(Num2Word_SN, self).__init__()
+
+    def setup(self):
+        super(Num2Word_SN, self).setup()
+        self.negword = "minus"
+        self.pointword = "poindi"
+
+    def _int_to_sn_word(self, number):
+        """Convert an integer to Shona words."""
+        
+        if number == 0:
+            return self.ones[0]
+        
+        if number < 0:
+            return self.negword + " " + self._int_to_sn_word(-number)
+            
+        if number <= 10:
+            return self.ones[number]
+            
+        # Numbers 11-19
+        if number < 20:
+            return "gumi ne" + self.ones[number - 10]
+            
+        # Numbers 20-99
+        if number < 100:
+            tens, units = divmod(number, 10)
+            if units == 0:
+                return "makumi " + self.tens_forms[tens]
+            else:
+                return "makumi " + self.tens_forms[tens] + " ne" + self.ones[units]
+                
+        # Numbers 100-999
+        if number < 1000:
+            hundreds, remainder = divmod(number, 100)
+            if hundreds == 1:
+                if remainder == 0:
+                    return "zana"
+                else:
+                    return "zana ne" + self._int_to_sn_word(remainder)
+            else:
+                if remainder == 0:
+                    return "mazana " + self.tens_forms[hundreds]
+                else:
+                    return "mazana " + self.tens_forms[hundreds] + " ne" + self._int_to_sn_word(remainder)
+                    
+        # Numbers 1000-9999
+        if number < 10000:
+            thousands, remainder = divmod(number, 1000)
+            if thousands == 1:
+                if remainder == 0:
+                    return "churu"
+                else:
+                    return "churu ne" + self._int_to_sn_word(remainder)
+            else:
+                if remainder == 0:
+                    if thousands < 10:
+                        return "zvuru zvi" + self._get_thousands_form(thousands)
+                    else:
+                        return "zvuru " + self._int_to_sn_word(thousands)
+                else:
+                    if thousands < 10:
+                        return "zvuru zvi" + self._get_thousands_form(thousands) + " ne" + self._int_to_sn_word(remainder)
+                    else:
+                        return "zvuru " + self._int_to_sn_word(thousands) + " ne" + self._int_to_sn_word(remainder)
+                        
+        # Numbers 10000-99999
+        if number < 100000:
+            ten_thousands, remainder = divmod(number, 1000)
+            if remainder == 0:
+                return "zvuru " + self._int_to_sn_word(ten_thousands)
+            else:
+                return "zvuru " + self._int_to_sn_word(ten_thousands) + " ne" + self._int_to_sn_word(remainder)
+                
+        # Numbers 100000-999999
+        if number < 1000000:
+            hundred_thousands, remainder = divmod(number, 1000)
+            if remainder == 0:
+                return "zvuru " + self._int_to_sn_word(hundred_thousands)
+            else:
+                return "zvuru " + self._int_to_sn_word(hundred_thousands) + " ne" + self._int_to_sn_word(remainder)
+                
+        # Millions
+        if number < 1000000000:
+            millions, remainder = divmod(number, 1000000)
+            if millions == 1:
+                if remainder == 0:
+                    return "miriyoni"
+                else:
+                    return "miriyoni ne" + self._int_to_sn_word(remainder)
+            else:
+                if remainder == 0:
+                    if millions == 2:
+                        return "miriyoni mbiri"
+                    elif millions < 10:
+                        return "miriyoni " + self.ones[millions] if millions in self.ones else "miriyoni " + self._int_to_sn_word(millions)
+                    else:
+                        return "miriyoni " + self._int_to_sn_word(millions)
+                else:
+                    if millions == 2:
+                        return "miriyoni mbiri ne" + self._int_to_sn_word(remainder)
+                    elif millions < 10:
+                        return "miriyoni " + (self.ones[millions] if millions in self.ones else self._int_to_sn_word(millions)) + " ne" + self._int_to_sn_word(remainder)
+                    else:
+                        return "miriyoni " + self._int_to_sn_word(millions) + " ne" + self._int_to_sn_word(remainder)
+                        
+        # Billions
+        if number < 1000000000000:
+            billions, remainder = divmod(number, 1000000000)
+            if billions == 1:
+                if remainder == 0:
+                    return "bhiriyoni"
+                else:
+                    return "bhiriyoni ne" + self._int_to_sn_word(remainder)
+            else:
+                if remainder == 0:
+                    return "bhiriyoni " + ("mbiri" if billions == 2 else self.ones[billions] if billions < 10 else self._int_to_sn_word(billions))
+                else:
+                    return "bhiriyoni " + ("mbiri" if billions == 2 else self.ones[billions] if billions < 10 else self._int_to_sn_word(billions)) + " ne" + self._int_to_sn_word(remainder)
+                    
+        # Trillions
+        trillions, remainder = divmod(number, 1000000000000)
+        if trillions == 1:
+            if remainder == 0:
+                return "tiriyoni"
+            else:
+                return "tiriyoni ne" + self._int_to_sn_word(remainder)
+        else:
+            if remainder == 0:
+                return "tiriyoni " + ("mbiri" if trillions == 2 else self.ones[trillions] if trillions < 10 else self._int_to_sn_word(trillions))
+            else:
+                return "tiriyoni " + ("mbiri" if trillions == 2 else self.ones[trillions] if trillions < 10 else self._int_to_sn_word(trillions)) + " ne" + self._int_to_sn_word(remainder)
+    
+    def _get_thousands_form(self, number):
+        """Get the special form for thousands (zvuru zvi...)"""
+        thousands_forms = {
+            2: 'viri',
+            3: 'tatu',
+            4: 'na',
+            5: 'shanu',
+            6: 'tanhatu',
+            7: 'nomwe',
+            8: 'sere',
+            9: 'pfumbamwe'
+        }
+        return thousands_forms.get(number, self.ones[number])
+    
+    def to_cardinal(self, number):
+        """Convert a number to its cardinal representation."""
+        try:
+            if isinstance(number, str):
+                number = int(number)
+            
+            # Handle floats
+            if isinstance(number, float):
+                return self.to_cardinal_float(number)
+                
+            return self._int_to_sn_word(number)
+            
+        except Exception:
+            return self._int_to_sn_word(int(number))
+    
+    def to_cardinal_float(self, number):
+        """Convert a float to its cardinal representation."""
+        sign = ""
+        if number < 0:
+            sign = self.negword + " "
+            number = abs(number)
+            
+        integer_part = int(number)
+        decimal_part = str(number).split('.')[1] if '.' in str(number) else ''
+        
+        result = self._int_to_sn_word(integer_part)
+        
+        if decimal_part:
+            result += " " + self.pointword
+            for digit in decimal_part:
+                result += " " + self.ones[int(digit)]
+                
+        if sign:
+            return sign + result
+        return result
+    
+    def to_ordinal(self, number):
+        """Convert a number to its ordinal representation."""
+        # For simple ordinals (1-10), use the direct mapping
+        if number in self.ordinals:
+            return self.ordinals[number]
+            
+        # For larger numbers, add "we" prefix to the cardinal
+        cardinal = self._int_to_sn_word(number)
+        
+        # Handle special cases for ordinals
+        if cardinal.startswith("gumi"):
+            return "we" + cardinal
+        elif cardinal.startswith("makumi"):
+            return "we" + cardinal  # Just add "we" prefix
+        elif cardinal.startswith("zana"):
+            return "we" + cardinal
+        elif cardinal.startswith("mazana"):
+            return "we" + cardinal[2:]  # Remove "ma" prefix
+        elif cardinal.startswith("churu"):
+            return "we" + cardinal
+        elif cardinal.startswith("zvuru"):
+            return "we" + cardinal[2:]  # Remove "zv" prefix
+        else:
+            return "we" + cardinal
+    
+    def to_ordinal_num(self, number):
+        """Convert a number to its abbreviated ordinal form."""
+        # Shona doesn't typically use abbreviated ordinals like "1st", "2nd"
+        # Return the number with a suffix indicator
+        return str(number) + "."
+    
+    def to_currency(self, n, currency='USD', cents=True, separator='ne'):
+        """Convert a number to a currency representation."""
+        result = []
+        value = self.float_to_value(n)
+        
+        if value < 0:
+            result.append(self.negword)
+            value = abs(value)
+            
+        integer_part, decimal_part = self._split_currency(value)
+        
+        # Get currency forms
+        if currency not in self.CURRENCY_FORMS:
+            raise NotImplementedError(f"Currency {currency} not implemented for Shona")
+            
+        currency_forms = self.CURRENCY_FORMS[currency]
+        major_singular, major_plural = currency_forms[0]
+        minor_singular, minor_plural = currency_forms[1]
+        
+        # Major currency unit
+        if integer_part == 1:
+            result.append(major_singular + " rimwe")
+        else:
+            # Use cardinal form but with "ma" prefix and appropriate forms
+            cardinal = self._int_to_sn_word(integer_part)
+            # Special handling for smaller numbers
+            if integer_part == 2:
+                result.append("ma" + major_singular + " maviri")
+            elif integer_part < 10 and integer_part in self.ones:
+                # Use tens_forms for consistency
+                if integer_part in self.tens_forms:
+                    result.append("ma" + major_singular + " " + self.tens_forms[integer_part])
+                else:
+                    result.append("ma" + major_singular + " " + cardinal)
+            else:
+                result.append("ma" + major_singular + " " + cardinal)
+            
+        # Minor currency unit (cents)
+        if cents and decimal_part:
+            if decimal_part == 1:
+                result.append(separator + minor_singular + " rimwe")
+            else:
+                # For cents, just use the minor_singular without "ma" prefix
+                result.append(separator + minor_singular + " " + self._int_to_sn_word(decimal_part))
+                
+        return " ".join(result)
+    
+    def _split_currency(self, value):
+        """Split a currency value into integer and decimal parts."""
+        integer_part = int(value)
+        decimal_part = int(round((value - integer_part) * 100))
+        return integer_part, decimal_part
+    
+    def to_year(self, number):
+        """Convert a number to a year representation."""
+        # In Shona, years are typically expressed as regular cardinal numbers
+        return self._int_to_sn_word(number)
+    
+    def float_to_value(self, n):
+        """Convert string or float to float value."""
+        if isinstance(n, str):
+            return float(n)
+        return n

--- a/tests/test_sn.py
+++ b/tests/test_sn.py
@@ -1,0 +1,227 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2003, Taro Ogawa.  All Rights Reserved.
+# Copyright (c) 2013, Savoir-faire Linux inc.  All Rights Reserved.
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
+from unittest import TestCase
+
+from num2words import num2words
+
+
+class Num2WordsSNTest(TestCase):
+    
+    def test_cardinal_numbers(self):
+        """Test cardinal numbers 0-20 in Shona"""
+        self.assertEqual(num2words(0, lang='sn'), 'zero')
+        self.assertEqual(num2words(1, lang='sn'), 'motsi')
+        self.assertEqual(num2words(2, lang='sn'), 'piri')
+        self.assertEqual(num2words(3, lang='sn'), 'tatu')
+        self.assertEqual(num2words(4, lang='sn'), 'china')
+        self.assertEqual(num2words(5, lang='sn'), 'shanu')
+        self.assertEqual(num2words(6, lang='sn'), 'tanhatu')
+        self.assertEqual(num2words(7, lang='sn'), 'nomwe')
+        self.assertEqual(num2words(8, lang='sn'), 'sere')
+        self.assertEqual(num2words(9, lang='sn'), 'pfumbamwe')
+        self.assertEqual(num2words(10, lang='sn'), 'gumi')
+        self.assertEqual(num2words(11, lang='sn'), 'gumi nemotsi')
+        self.assertEqual(num2words(12, lang='sn'), 'gumi nepiri')
+        self.assertEqual(num2words(13, lang='sn'), 'gumi netatu')
+        self.assertEqual(num2words(14, lang='sn'), 'gumi nechina')
+        self.assertEqual(num2words(15, lang='sn'), 'gumi neshanu')
+        self.assertEqual(num2words(16, lang='sn'), 'gumi netanhatu')
+        self.assertEqual(num2words(17, lang='sn'), 'gumi nenomwe')
+        self.assertEqual(num2words(18, lang='sn'), 'gumi nesere')
+        self.assertEqual(num2words(19, lang='sn'), 'gumi nepfumbamwe')
+        self.assertEqual(num2words(20, lang='sn'), 'makumi maviri')
+
+    def test_tens(self):
+        """Test tens (20, 30, 40, etc.) in Shona"""
+        self.assertEqual(num2words(20, lang='sn'), 'makumi maviri')
+        self.assertEqual(num2words(30, lang='sn'), 'makumi matatu')
+        self.assertEqual(num2words(40, lang='sn'), 'makumi mana')
+        self.assertEqual(num2words(50, lang='sn'), 'makumi mashanu')
+        self.assertEqual(num2words(60, lang='sn'), 'makumi matanhatu')
+        self.assertEqual(num2words(70, lang='sn'), 'makumi manomwe')
+        self.assertEqual(num2words(80, lang='sn'), 'makumi masere')
+        self.assertEqual(num2words(90, lang='sn'), 'makumi mapfumbamwe')
+
+    def test_compound_numbers(self):
+        """Test compound numbers (21-99) in Shona"""
+        self.assertEqual(num2words(21, lang='sn'), 'makumi maviri nemotsi')
+        self.assertEqual(num2words(25, lang='sn'), 'makumi maviri neshanu')
+        self.assertEqual(num2words(35, lang='sn'), 'makumi matatu neshanu')
+        self.assertEqual(num2words(47, lang='sn'), 'makumi mana nenomwe')
+        self.assertEqual(num2words(59, lang='sn'), 'makumi mashanu nepfumbamwe')
+        self.assertEqual(num2words(64, lang='sn'), 'makumi matanhatu nechina')
+        self.assertEqual(num2words(78, lang='sn'), 'makumi manomwe nesere')
+        self.assertEqual(num2words(82, lang='sn'), 'makumi masere nepiri')
+        self.assertEqual(num2words(99, lang='sn'), 'makumi mapfumbamwe nepfumbamwe')
+
+    def test_hundreds(self):
+        """Test hundreds in Shona"""
+        self.assertEqual(num2words(100, lang='sn'), 'zana')
+        self.assertEqual(num2words(200, lang='sn'), 'mazana maviri')
+        self.assertEqual(num2words(300, lang='sn'), 'mazana matatu')
+        self.assertEqual(num2words(400, lang='sn'), 'mazana mana')
+        self.assertEqual(num2words(500, lang='sn'), 'mazana mashanu')
+        self.assertEqual(num2words(600, lang='sn'), 'mazana matanhatu')
+        self.assertEqual(num2words(700, lang='sn'), 'mazana manomwe')
+        self.assertEqual(num2words(800, lang='sn'), 'mazana masere')
+        self.assertEqual(num2words(900, lang='sn'), 'mazana mapfumbamwe')
+
+    def test_hundreds_with_tens_and_units(self):
+        """Test hundreds with tens and units in Shona"""
+        self.assertEqual(num2words(101, lang='sn'), 'zana nemotsi')
+        self.assertEqual(num2words(111, lang='sn'), 'zana negumi nemotsi')
+        self.assertEqual(num2words(125, lang='sn'), 'zana nemakumi maviri neshanu')
+        self.assertEqual(num2words(235, lang='sn'), 'mazana maviri nemakumi matatu neshanu')
+        self.assertEqual(num2words(345, lang='sn'), 'mazana matatu nemakumi mana neshanu')
+        self.assertEqual(num2words(456, lang='sn'), 'mazana mana nemakumi mashanu netanhatu')
+        self.assertEqual(num2words(567, lang='sn'), 'mazana mashanu nemakumi matanhatu nenomwe')
+        self.assertEqual(num2words(678, lang='sn'), 'mazana matanhatu nemakumi manomwe nesere')
+        self.assertEqual(num2words(789, lang='sn'), 'mazana manomwe nemakumi masere nepfumbamwe')
+        self.assertEqual(num2words(999, lang='sn'), 'mazana mapfumbamwe nemakumi mapfumbamwe nepfumbamwe')
+
+    def test_thousands(self):
+        """Test thousands in Shona"""
+        self.assertEqual(num2words(1000, lang='sn'), 'churu')
+        self.assertEqual(num2words(2000, lang='sn'), 'zvuru zviviri')
+        self.assertEqual(num2words(3000, lang='sn'), 'zvuru zvitatu')
+        self.assertEqual(num2words(4000, lang='sn'), 'zvuru zvina')
+        self.assertEqual(num2words(5000, lang='sn'), 'zvuru zvishanu')
+        self.assertEqual(num2words(6000, lang='sn'), 'zvuru zvitanhatu')
+        self.assertEqual(num2words(7000, lang='sn'), 'zvuru zvinomwe')
+        self.assertEqual(num2words(8000, lang='sn'), 'zvuru zvisere')
+        self.assertEqual(num2words(9000, lang='sn'), 'zvuru zvipfumbamwe')
+        self.assertEqual(num2words(10000, lang='sn'), 'zvuru gumi')
+
+    def test_thousands_complex(self):
+        """Test complex thousand numbers in Shona"""
+        self.assertEqual(num2words(1001, lang='sn'), 'churu nemotsi')
+        self.assertEqual(num2words(1010, lang='sn'), 'churu negumi')
+        self.assertEqual(num2words(1100, lang='sn'), 'churu nezana')
+        self.assertEqual(num2words(1234, lang='sn'), 'churu nemazana maviri nemakumi matatu nechina')
+        self.assertEqual(num2words(2345, lang='sn'), 'zvuru zviviri nemazana matatu nemakumi mana neshanu')
+        self.assertEqual(num2words(5678, lang='sn'), 'zvuru zvishanu nemazana matanhatu nemakumi manomwe nesere')
+        self.assertEqual(num2words(9999, lang='sn'), 'zvuru zvipfumbamwe nemazana mapfumbamwe nemakumi mapfumbamwe nepfumbamwe')
+        self.assertEqual(num2words(10001, lang='sn'), 'zvuru gumi nemotsi')
+        self.assertEqual(num2words(15000, lang='sn'), 'zvuru gumi neshanu')
+        self.assertEqual(num2words(20000, lang='sn'), 'zvuru makumi maviri')
+        self.assertEqual(num2words(25000, lang='sn'), 'zvuru makumi maviri neshanu')
+        self.assertEqual(num2words(99999, lang='sn'), 'zvuru makumi mapfumbamwe nepfumbamwe nemazana mapfumbamwe nemakumi mapfumbamwe nepfumbamwe')
+
+    def test_hundred_thousands(self):
+        """Test hundred thousands in Shona"""
+        self.assertEqual(num2words(100000, lang='sn'), 'zvuru zana')
+        self.assertEqual(num2words(200000, lang='sn'), 'zvuru mazana maviri')
+        self.assertEqual(num2words(500000, lang='sn'), 'zvuru mazana mashanu')
+        self.assertEqual(num2words(999999, lang='sn'), 'zvuru mazana mapfumbamwe nemakumi mapfumbamwe nepfumbamwe nemazana mapfumbamwe nemakumi mapfumbamwe nepfumbamwe')
+
+    def test_millions(self):
+        """Test millions in Shona"""
+        self.assertEqual(num2words(1000000, lang='sn'), 'miriyoni')
+        self.assertEqual(num2words(2000000, lang='sn'), 'miriyoni mbiri')
+        self.assertEqual(num2words(5000000, lang='sn'), 'miriyoni shanu')
+        self.assertEqual(num2words(1000001, lang='sn'), 'miriyoni nemotsi')
+        self.assertEqual(num2words(1234567, lang='sn'), 'miriyoni nezvuru mazana maviri nemakumi matatu nechina nemazana mashanu nemakumi matanhatu nenomwe')
+        self.assertEqual(num2words(9999999, lang='sn'), 'miriyoni pfumbamwe nezvuru mazana mapfumbamwe nemakumi mapfumbamwe nepfumbamwe nemazana mapfumbamwe nemakumi mapfumbamwe nepfumbamwe')
+
+    def test_negative_numbers(self):
+        """Test negative numbers in Shona"""
+        self.assertEqual(num2words(-1, lang='sn'), 'minus motsi')
+        self.assertEqual(num2words(-5, lang='sn'), 'minus shanu')
+        self.assertEqual(num2words(-10, lang='sn'), 'minus gumi')
+        self.assertEqual(num2words(-15, lang='sn'), 'minus gumi neshanu')
+        self.assertEqual(num2words(-20, lang='sn'), 'minus makumi maviri')
+        self.assertEqual(num2words(-100, lang='sn'), 'minus zana')
+        self.assertEqual(num2words(-234, lang='sn'), 'minus mazana maviri nemakumi matatu nechina')
+        self.assertEqual(num2words(-1000, lang='sn'), 'minus churu')
+        self.assertEqual(num2words(-999999, lang='sn'), 'minus zvuru mazana mapfumbamwe nemakumi mapfumbamwe nepfumbamwe nemazana mapfumbamwe nemakumi mapfumbamwe nepfumbamwe')
+
+    def test_decimal_numbers(self):
+        """Test decimal numbers in Shona"""
+        self.assertEqual(num2words(0.5, lang='sn'), 'zero poindi shanu')
+        self.assertEqual(num2words(0.7, lang='sn'), 'zero poindi nomwe')
+        self.assertEqual(num2words(1.5, lang='sn'), 'motsi poindi shanu')
+        self.assertEqual(num2words(2.3, lang='sn'), 'piri poindi tatu')
+        self.assertEqual(num2words(5.75, lang='sn'), 'shanu poindi nomwe shanu')
+        self.assertEqual(num2words(10.5, lang='sn'), 'gumi poindi shanu')
+        self.assertEqual(num2words(15.25, lang='sn'), 'gumi neshanu poindi piri shanu')
+        self.assertEqual(num2words(100.01, lang='sn'), 'zana poindi zero motsi')
+        self.assertEqual(num2words(999.99, lang='sn'), 'mazana mapfumbamwe nemakumi mapfumbamwe nepfumbamwe poindi pfumbamwe pfumbamwe')
+
+    def test_negative_decimals(self):
+        """Test negative decimal numbers in Shona"""
+        self.assertEqual(num2words(-0.4, lang='sn'), 'minus zero poindi china')
+        self.assertEqual(num2words(-0.5, lang='sn'), 'minus zero poindi shanu')
+        self.assertEqual(num2words(-1.4, lang='sn'), 'minus motsi poindi china')
+        self.assertEqual(num2words(-10.25, lang='sn'), 'minus gumi poindi piri shanu')
+        self.assertEqual(num2words(-100.5, lang='sn'), 'minus zana poindi shanu')
+
+    def test_ordinal_numbers(self):
+        """Test ordinal numbers in Shona"""
+        self.assertEqual(num2words(1, lang='sn', to='ordinal'), 'wekutanga')
+        self.assertEqual(num2words(2, lang='sn', to='ordinal'), 'wechipiri')
+        self.assertEqual(num2words(3, lang='sn', to='ordinal'), 'wechitatu')
+        self.assertEqual(num2words(4, lang='sn', to='ordinal'), 'wechina')
+        self.assertEqual(num2words(5, lang='sn', to='ordinal'), 'wechishanu')
+        self.assertEqual(num2words(6, lang='sn', to='ordinal'), 'wechitanhatu')
+        self.assertEqual(num2words(7, lang='sn', to='ordinal'), 'wechinomwe')
+        self.assertEqual(num2words(8, lang='sn', to='ordinal'), 'wechisere')
+        self.assertEqual(num2words(9, lang='sn', to='ordinal'), 'wechipfumbamwe')
+        self.assertEqual(num2words(10, lang='sn', to='ordinal'), 'wegumi')
+        self.assertEqual(num2words(11, lang='sn', to='ordinal'), 'wegumi nemotsi')
+        self.assertEqual(num2words(20, lang='sn', to='ordinal'), 'wemakumi maviri')
+        self.assertEqual(num2words(21, lang='sn', to='ordinal'), 'wemakumi maviri nemotsi')
+        self.assertEqual(num2words(100, lang='sn', to='ordinal'), 'wezana')
+        self.assertEqual(num2words(1000, lang='sn', to='ordinal'), 'wechuru')
+
+    def test_currency(self):
+        """Test currency conversion in Shona"""
+        self.assertEqual(
+            num2words(1, lang='sn', to='currency', currency='USD'),
+            'dhora rimwe'
+        )
+        self.assertEqual(
+            num2words(2, lang='sn', to='currency', currency='USD'),
+            'madhora maviri'
+        )
+        self.assertEqual(
+            num2words(5.50, lang='sn', to='currency', currency='USD'),
+            'madhora mashanu nesendi makumi mashanu'
+        )
+        self.assertEqual(
+            num2words(100, lang='sn', to='currency', currency='USD'),
+            'madhora zana'
+        )
+        self.assertEqual(
+            num2words(1234.56, lang='sn', to='currency', currency='USD'),
+            'madhora churu nemazana maviri nemakumi matatu nechina nesendi makumi mashanu netanhatu'
+        )
+
+    def test_year(self):
+        """Test year conversion in Shona"""
+        self.assertEqual(num2words(1990, lang='sn', to='year'), 'churu nemazana mapfumbamwe nemakumi mapfumbamwe')
+        self.assertEqual(num2words(2000, lang='sn', to='year'), 'zvuru zviviri')
+        self.assertEqual(num2words(2024, lang='sn', to='year'), 'zvuru zviviri nemakumi maviri nechina')
+        self.assertEqual(num2words(1066, lang='sn', to='year'), 'churu nemakumi matanhatu netanhatu')
+        self.assertEqual(num2words(1865, lang='sn', to='year'), 'churu nemazana masere nemakumi matanhatu neshanu')
+
+    def test_large_numbers(self):
+        """Test large numbers beyond millions in Shona"""
+        self.assertEqual(num2words(1000000000, lang='sn'), 'bhiriyoni')
+        self.assertEqual(num2words(2000000000, lang='sn'), 'bhiriyoni mbiri')
+        self.assertEqual(num2words(1000000000000, lang='sn'), 'tiriyoni')
+        self.assertEqual(num2words(2000000000000, lang='sn'), 'tiriyoni mbiri')


### PR DESCRIPTION
- Added complete Shona language implementation (lang_SN.py)
- Supports cardinal, ordinal, decimal, negative, and currency numbers
- Handles numbers from 0 to trillions with proper Shona grammar
- Includes special forms for thousands (zvuru zvi-) and millions (mbiri for 2)
- Added comprehensive test suite with 16 test methods covering all number types
- Supports USD, ZWL, and ZAR currency conversions
- All tests passing successfully

Shona (chiShona) is a Bantu language spoken in Zimbabwe and Mozambique.
