### PR TITLE
Port: Italian — 9 new currency forms [upstream #612]

### DIFF
--- a/num2words2/lang_IT.py
+++ b/num2words2/lang_IT.py
@@ -151,9 +151,18 @@ class Num2Word_IT(Num2Word_EUR):
     CURRENCY_FORMS = {
         "EUR": (("euro", "euro"), GENERIC_CENTS),
         "USD": (GENERIC_DOLLARS, GENERIC_CENTS),
+        "CAD": (GENERIC_DOLLARS, GENERIC_CENTS),
+        "AUD": (GENERIC_DOLLARS, GENERIC_CENTS),
+        "NZD": (GENERIC_DOLLARS, GENERIC_CENTS),
+        "HKD": (GENERIC_DOLLARS, GENERIC_CENTS),
         "GBP": (("sterlina", "sterline"), ("penny", "penny")),
         "CNY": (("yuan", "yuan"), ("fen", "fen")),
         "CHF": (("franco", "franchi"), GENERIC_CENTS),
+        "JPY": (("yen", "yen"), ("sen", "sen")),
+        "INR": (("rupia", "rupie"), ("paisa", "paise")),
+        "RUB": (("rublo", "rubli"), ("copeco", "copechi")),
+        "KRW": (("won", "won"), ("jeon", "jeon")),
+        "MXN": (("peso", "pesos"), GENERIC_CENTS),
     }
     MINUS_PREFIX_WORD = "meno "
     FLOAT_INFIX_WORD = " virgola "


### PR DESCRIPTION
Ports [savoirfairelinux/num2words#612](https://github.com/savoirfairelinux/num2words/pull/612) by @bryananderson.

## Summary
Adds CAD, AUD, NZD, HKD, JPY, INR, RUB, KRW, and MXN to Italian (`lang_IT`) currency forms.

## Test plan
- [x] Existing 20 Italian tests still green
- [x] Smoke check confirmed each new currency renders correctly (e.g. RUB → "rublo/rubli/copeco/copechi")

## Credit
Original author: @bryananderson.

Original upstream PR: https://github.com/savoirfairelinux/num2words/pull/612

🤖 Generated with [Claude Code](https://claude.com/claude-code)