### PR TITLE
Port: German — new currency forms [upstream #613]

### DIFF
--- a/num2words2/lang_DE.py
+++ b/num2words2/lang_DE.py
@@ -27,10 +27,18 @@ class Num2Word_DE(Num2Word_EUR):
         "EUR": (("Euro", "Euro"), ("Cent", "Cent")),
         "GBP": (("Pfund", "Pfund"), ("Penny", "Pence")),
         "USD": (("Dollar", "Dollar"), ("Cent", "Cent")),
+        "CAD": (("Dollar", "Dollar"), ("Cent", "Cent")),
+        "AUD": (("Dollar", "Dollar"), ("Cent", "Cent")),
+        "NZD": (("Dollar", "Dollar"), ("Cent", "Cent")),
+        "HKD": (("Dollar", "Dollar"), ("Cent", "Cent")),
         "CNY": (("Yuan", "Yuan"), ("Jiao", "Fen")),
         "DEM": (("Mark", "Mark"), ("Pfennig", "Pfennig")),
         "CHF": (("Schweizer Franken", "Schweizer Franken"), ("Rappen", "Rappen")),
         "JPY": (("Yen", "Yen"), ("Sen", "Sen")),
+        "INR": (("Rupie", "Rupien"), ("Paisa", "Paisa")),
+        "RUB": (("Rubel", "Rubel"), ("Kopeke", "Kopeken")),
+        "KRW": (("Won", "Won"), ("Jeon", "Jeon")),
+        "MXN": (("Peso", "Pesos"), ("Centavo", "Centavos")),
     }
 
     GIGA_SUFFIX = "illiarde"


### PR DESCRIPTION
Ports [savoirfairelinux/num2words#613](https://github.com/savoirfairelinux/num2words/pull/613) by @bryananderson.

## Summary
Adds CAD, AUD, NZD, HKD, INR, RUB, KRW, and MXN currency forms to German (`lang_DE`).

Note: kept num2words2's existing CNY sub-unit naming ("Jiao/Fen") rather than upstream's normalization to ("Fen/Fen") to avoid regressing the existing test suite.

## Test plan
- [x] Existing 16 German tests still green

## Credit
Original author: @bryananderson.

Original upstream PR: https://github.com/savoirfairelinux/num2words/pull/613

🤖 Generated with [Claude Code](https://claude.com/claude-code)