### PR TITLE
Port: French — new currency forms [upstream #614]

### DIFF
--- a/num2words2/lang_FR.py
+++ b/num2words2/lang_FR.py
@@ -25,9 +25,17 @@ class Num2Word_FR(Num2Word_EUR):
         "EUR": (("euro", "euros"), ("centime", "centimes")),
         "USD": (("dollar", "dollars"), ("cent", "cents")),
         "FRF": (("franc", "francs"), ("centime", "centimes")),
+        "CAD": (("dollar", "dollars"), ("cent", "cents")),
+        "AUD": (("dollar", "dollars"), ("cent", "cents")),
+        "NZD": (("dollar", "dollars"), ("cent", "cents")),
+        "HKD": (("dollar", "dollars"), ("cent", "cents")),
         "GBP": (("livre", "livres"), ("penny", "pence")),
         "CNY": (("yuan", "yuans"), ("fen", "jiaos")),
         "JPY": (("yen", "yens"), ("sen", "sens")),
+        "INR": (("roupie", "roupies"), ("paisa", "paisas")),
+        "RUB": (("rouble", "roubles"), ("kopeck", "kopecks")),
+        "KRW": (("won", "wons"), ("jeon", "jeons")),
+        "MXN": (("peso", "pesos"), ("centavo", "centavos")),
     }
 
     def setup(self):


### PR DESCRIPTION
Ports [savoirfairelinux/num2words#614](https://github.com/savoirfairelinux/num2words/pull/614) by @bryananderson.

## Summary
Adds CAD, AUD, NZD, HKD, INR, RUB, KRW, and MXN currency forms to French (`lang_FR`).

## Test plan
- [x] Existing 9 French tests still green

## Credit
Original author: @bryananderson.

Original upstream PR: https://github.com/savoirfairelinux/num2words/pull/614

🤖 Generated with [Claude Code](https://claude.com/claude-code)