### PR TITLE
Port: Portuguese — new currency forms [upstream #615]

### DIFF
--- a/num2words2/lang_PT.py
+++ b/num2words2/lang_PT.py
@@ -30,8 +30,16 @@ class Num2Word_PT(Num2Word_EUR):
         "AUD": (DOLLAR, CENTS),
         "BRL": (("real", "reais"), ("centavo", "centavos")),
         "CAD": (DOLLAR, CENTS),
+        "NZD": (DOLLAR, CENTS),
+        "HKD": (DOLLAR, CENTS),
         "EUR": (("euro", "euros"), CENTS),
         "GBP": (("libra", "libras"), ("péni", "pence")),
+        "CNY": (("yuan", "yuans"), ("fen", "fen")),
+        "JPY": (("iene", "ienes"), ("sen", "sen")),
+        "INR": (("rupia", "rupias"), ("paisa", "paisas")),
+        "RUB": (("rublo", "rublos"), ("copeque", "copeques")),
+        "KRW": (("won", "wons"), ("jeon", "jeons")),
+        "MXN": (("peso", "pesos"), ("centavo", "centavos")),
         "USD": (DOLLAR, CENTS),
     }
 


### PR DESCRIPTION
Ports [savoirfairelinux/num2words#615](https://github.com/savoirfairelinux/num2words/pull/615) by @bryananderson.

## Summary
Adds NZD, HKD, CNY, JPY, INR, RUB, KRW, and MXN currency forms to Portuguese (`lang_PT`).

## Test plan
- [x] Existing 13 Portuguese tests still green

## Credit
Original author: @bryananderson.

Original upstream PR: https://github.com/savoirfairelinux/num2words/pull/615

🤖 Generated with [Claude Code](https://claude.com/claude-code)