### PR TITLE
Port: Spanish CRC sub-unit fix [upstream #467]

### DIFF
--- a/num2words2/lang_ES.py
+++ b/num2words2/lang_ES.py
@@ -61,7 +61,7 @@ class Num2Word_ES(Num2Word_EUR):
         "ESP": (("peseta", "pesetas"), ("céntimo", "céntimos")),
         "USD": (GENERIC_DOLLARS, GENERIC_CENTS),
         "PEN": (("sol", "soles"), ("céntimo", "céntimos")),
-        "CRC": (("colón", "colones"), GENERIC_CENTS),
+        "CRC": (("colón", "colones"), ("céntimo", "céntimos")),
         "AUD": (GENERIC_DOLLARS, GENERIC_CENTS),
         "CAD": (GENERIC_DOLLARS, GENERIC_CENTS),
         "GBP": (("libra", "libras"), ("penique", "peniques")),

--- a/tests/lang/test_es.py
+++ b/tests/lang/test_es.py
@@ -175,15 +175,15 @@ TEST_CASES_TO_CURRENCY_PEN = (
 )
 
 TEST_CASES_TO_CURRENCY_CRC = (
-    (1.00, "uno colón con cero centavos"),
-    (2.00, "dos colones con cero centavos"),
-    (8.00, "ocho colones con cero centavos"),
-    (12.00, "doce colones con cero centavos"),
-    (21.00, "veintiuno colones con cero centavos"),
-    (81.25, "ochenta y uno colones con veinticinco centavos"),
-    (350.90, "trescientos cincuenta colones con noventa centavos"),
-    (100.00, "cien colones con cero centavos"),
-    (4150.83, "cuatro mil ciento cincuenta colones con ochenta y tres centavos"),
+    (1.00, "uno colón con cero céntimos"),
+    (2.00, "dos colones con cero céntimos"),
+    (8.00, "ocho colones con cero céntimos"),
+    (12.00, "doce colones con cero céntimos"),
+    (21.00, "veintiuno colones con cero céntimos"),
+    (81.25, "ochenta y uno colones con veinticinco céntimos"),
+    (350.90, "trescientos cincuenta colones con noventa céntimos"),
+    (100.00, "cien colones con cero céntimos"),
+    (4150.83, "cuatro mil ciento cincuenta colones con ochenta y tres céntimos"),
 )
 
 TEST_CASES_TO_CURRENCY_GBP = (


### PR DESCRIPTION
Ports [savoirfairelinux/num2words#467](https://github.com/savoirfairelinux/num2words/pull/467) by @pmadriz.

## Summary
Costa Rican colón sub-unit corrected from "centavo/centavos" to "céntimo/céntimos" — matches the form used by Banco Central de Costa Rica.

## Test plan
- [x] All 176 Spanish tests still green (existing CRC tests updated to expect new wording)

## Credit
Original author: @pmadriz.

Original upstream PR: https://github.com/savoirfairelinux/num2words/pull/467

🤖 Generated with [Claude Code](https://claude.com/claude-code)