### PR TITLE
Port: Arabic — Lebanese Pound (LBP) currency [upstream #538]

### DIFF
--- a/num2words2/lang_AR.py
+++ b/num2words2/lang_AR.py
@@ -34,6 +34,10 @@ CURRENCY_KWD = [
     ("دينار", "ديناران", "دينارات", "ديناراً"),
     ("فلس", "فلسان", "فلس", "فلس"),
 ]
+CURRENCY_LBP = [
+    ("ليرة", "ليرتان", "ليرات", "ليرة"),
+    ("قرش", "قرشان", "قروش", "قرش"),
+]
 CURRENCY_TND = [
     ("دينار", "ديناران", "دينارات", "ديناراً"),
     ("مليماً", "ميلمان", "مليمات", "مليم"),
@@ -494,6 +498,10 @@ class Num2Word_AR(Num2Word_Base):
         elif currency == "KWD":
             self.currency_unit = CURRENCY_KWD[0]
             self.currency_subunit = CURRENCY_KWD[1]
+            self.partPrecision = 2
+        elif currency == "LBP":
+            self.currency_unit = CURRENCY_LBP[0]
+            self.currency_subunit = CURRENCY_LBP[1]
             self.partPrecision = 2
         else:
             self.currency_unit = CURRENCY_SR[0]


### PR DESCRIPTION
Ports [savoirfairelinux/num2words#538](https://github.com/savoirfairelinux/num2words/pull/538) by @davegreeko2023.

## Summary
Adds LBP (Lebanese Pound / ليرة لبنانية) to Arabic (`lang_AR`) currency preferences. Sub-unit is the قرش (qirsh).

## Test plan
- [x] Existing 9 Arabic tests still green
- [x] Smoke check confirmed LBP output: `123.45` → "مائة وثلاثة وعشرون ليرة وخمس وأربعون قرش"

## Credit
Original author: @davegreeko2023.

Original upstream PR: https://github.com/savoirfairelinux/num2words/pull/538

🤖 Generated with [Claude Code](https://claude.com/claude-code)