### PR TITLE
Port: en_IN — support arab/kharab scale [upstream #654]

### DIFF
--- a/num2words2/lang_EN_IN.py
+++ b/num2words2/lang_EN_IN.py
@@ -22,5 +22,7 @@ from .lang_EN import Num2Word_EN
 
 class Num2Word_EN_IN(Num2Word_EN):
     def set_high_numwords(self, high):
+        self.cards[10**11] = "kharab"
+        self.cards[10**9] = "arab"
         self.cards[10**7] = "crore"
         self.cards[10**5] = "lakh"


### PR DESCRIPTION
Ports [savoirfairelinux/num2words#654](https://github.com/savoirfairelinux/num2words/pull/654) by @shrutiichandra.

## Summary
Extends en_IN's Indian-numbering-system scale beyond crore:

| Power | Word |
|---|---|
| 10⁵ | lakh (existing) |
| 10⁷ | crore (existing) |
| 10⁹ | **arab** (new) |
| 10¹¹ | **kharab** (new) |

## Test plan
- [x] All 5 EN_IN tests still green
- [x] \`9907781961\` → "nine arab, ninety crore, seventy-seven lakh, eighty-one thousand, nine hundred and sixty-one"
- [x] \`155215059811\` → "one kharab, fifty-five arab, twenty-one crore, fifty lakh, fifty-nine thousand, eight hundred and eleven"

## Credit
Original author: @shrutiichandra.

Original upstream PR: https://github.com/savoirfairelinux/num2words/pull/654

🤖 Generated with [Claude Code](https://claude.com/claude-code)