### PR TITLE
Port: Kannada — fix lakh prefix [upstream #588]

### DIFF
--- a/num2words2/lang_KN.py
+++ b/num2words2/lang_KN.py
@@ -131,7 +131,7 @@ class Num2Word_KN(Num2Word_EUR):
 
         self.mid_numwords = [(100, "ನೂರು")]
 
-        self.high_numwords = [(7, "ಕೋಟಿ"), (5, "ಒಂದು ಲಕ್ಷ"), (3, "ಸಾವಿರ")]
+        self.high_numwords = [(7, "ಕೋಟಿ"), (5, "ಲಕ್ಷ"), (3, "ಸಾವಿರ")]
 
         self.pointword = "ಬಿಂದು"
 


### PR DESCRIPTION
Ports [savoirfairelinux/num2words#588](https://github.com/savoirfairelinux/num2words/pull/588) by @timepas.

## Summary
The high-numword entry for 10⁵ hardcoded \`"ಒಂದು ಲಕ್ಷ"\` (literally "one lakh"), which caused multipliers > 1 to double-prefix (e.g. "ಎರಡು ಒಂದು ಲಕ್ಷ" for 200000 instead of "ಎರಡು ಲಕ್ಷ"). Dropping the redundant "ಒಂದು" lets counting prefixes flow correctly.

## Test plan
- [x] All 5 KN tests still green
- [x] \`100000\` → \`ಒಂದು ಲಕ್ಷ\` (the "ಒಂದು" comes from the multiplier resolver, not the static template)

## Credit
Original author: @timepas.

Original upstream PR: https://github.com/savoirfairelinux/num2words/pull/588

🤖 Generated with [Claude Code](https://claude.com/claude-code)