### PR TITLE
Port: Italian — preserve "diciotto" in compounds [upstream #632/#633]

### DIFF
--- a/num2words2/lang_IT.py
+++ b/num2words2/lang_IT.py
@@ -122,6 +122,11 @@ def accentuate(string):
 
 
 def phonetic_contraction(string):
+    # "diciotto" must not be contracted to "dicotto" — it is the canonical
+    # Italian form for 18, even when embedded in compounds like "centodiciotto".
+    if "diciotto" in string:
+        return string
+
     return (
         string.replace("oo", "o")  # ex. "centootto"
         .replace("ao", "o")  # ex. "settantaotto"


### PR DESCRIPTION
Ports [savoirfairelinux/num2words#632](https://github.com/savoirfairelinux/num2words/pull/632) and [#633](https://github.com/savoirfairelinux/num2words/pull/633) by @sydneyfi & Paola L. (resolves upstream #552).

## Summary
The Italian phonetic-contraction step ran "io→o" globally, so any number containing "diciotto" (18) was incorrectly contracted to "dicotto":

| Input | Before | After |
|---|---|---|
| 118 | centodicotto | **centodiciotto** |
| 1018 | millediciotto* | millediciotto |
| 11018 | undicimiladicotto | **undicimiladiciotto** |
| 100018 | centomiladicotto | **centomiladiciotto** |

Fix: short-circuit the contraction when the string already contains "diciotto".

## Test plan
- [x] All 20 Italian tests still green
- [x] Numbers 118/218/318/.../518/1018/11018/100018 all preserve "diciotto"

## Credit
Original authors: @sydneyfi & Paola L.

Original upstream PRs: https://github.com/savoirfairelinux/num2words/pull/632, https://github.com/savoirfairelinux/num2words/pull/633

🤖 Generated with [Claude Code](https://claude.com/claude-code)