### PR TITLE
Port: Korean — fix to_ordinal KeyError on hundreds [upstream #556]

### DIFF
--- a/num2words2/lang_KO.py
+++ b/num2words2/lang_KO.py
@@ -17,6 +17,8 @@
 
 from __future__ import division, print_function, unicode_literals
 
+import re
+
 from .base import Num2Word_Base
 from .currency import parse_currency_parts
 
@@ -110,20 +112,22 @@ class Num2Word_KO(Num2Word_Base):
         if value == 1:
             return "첫 번째"
         outwords = self.to_cardinal(value).split(" ")
-        lastwords = outwords[-1].split("백")
-        if "십" in lastwords[-1]:
-            ten_one = lastwords[-1].split("십")
-            ten_one[0] = self.ords[ten_one[0] + "십"]
-            try:
-                ten_one[1] = self.ords[ten_one[1]]
-                ten_one[0] = ten_one[0].replace("스무", "스물")
-            except KeyError:
-                pass
-            lastwords[-1] = "".join(ten_one)
-        else:
-            lastwords[-1] = self.ords[lastwords[-1]]
-        outwords[-1] = "백 ".join(lastwords)
-        return " ".join(outwords) + " 번째"
+        if value % 100 != 0:
+            re_mid_words = "|".join(
+                "(?<={})".format(re.escape(d)) for d in ["천", "백"]
+            )
+            lastwords = re.split(re_mid_words, outwords[-1])
+            if "십" in lastwords[-1]:
+                ten_one = lastwords[-1].split("십")
+                ten_one[0] = self.ords.get(ten_one[0] + "십", ten_one[0] + "십")
+                ten_one[1] = self.ords.get(ten_one[1], ten_one[1])
+                if not ten_one[1]:
+                    ten_one[0] = ten_one[0].replace("스물", "스무")
+                lastwords[-1] = "".join(ten_one)
+            else:
+                lastwords[-1] = self.ords.get(lastwords[-1], lastwords[-1])
+            outwords[-1] = "".join(lastwords)
+        return " ".join(x.strip() for x in outwords if x.strip()) + " 번째"
 
     def to_ordinal_num(self, value):
         self.verify_ordinal(value)

--- a/tests/lang/test_ko.py
+++ b/tests/lang/test_ko.py
@@ -137,12 +137,12 @@ class Num2WordsKOTest(TestCase):
     def test_ordinal(self):
         cases = [
             (1, "첫 번째"),
-            (101, "백 한 번째"),
+            (101, "백한 번째"),
             (2, "두 번째"),
             (5, "다섯 번째"),
             (10, "열 번째"),
             (25, "스물다섯 번째"),
-            (137, "백 서른일곱 번째"),
+            (137, "백서른일곱 번째"),
         ]
         for num, out in cases:
             self.assertEqual(n2k(num, to="ordinal"), out)


### PR DESCRIPTION
Ports [savoirfairelinux/num2words#556](https://github.com/savoirfairelinux/num2words/pull/556) by @dogzz9445 (resolves upstream #555).

## Summary

Korean \`to_ordinal\` previously crashed with \`KeyError\` for any multiple of 100:

\`\`\`python
>>> num2words(100, lang='ko', ordinal=True)
KeyError: ''
\`\`\`

The old split-on-"백" logic assumed the trailing slice always contained a tens word or a single-digit form, but for 100/200/.../1000 it was empty. The fix uses a positive-lookbehind regex split that keeps "천"/"백" attached to preceding tokens, falls back to identity mapping for missing dict entries, and rejoins without injecting spaces.

## Test plan

- [x] All 9 KO tests still green (after updating two tests for the new rejoin semantics)
- [x] \`100 → "백 번째"\`, \`101 → "백한 번째"\`, \`137 → "백서른일곱 번째"\`, \`555 → "오백쉰다섯 번째"\`
- [x] No more \`KeyError\` on multiples of 100

## Credit
Original author: @dogzz9445.

Original upstream PR: https://github.com/savoirfairelinux/num2words/pull/556

🤖 Generated with [Claude Code](https://claude.com/claude-code)