### PR TITLE
Port: Romanian — "de" particle for 20+ million multipliers [upstream #499]

### DIFF
--- a/num2words2/lang_RO.py
+++ b/num2words2/lang_RO.py
@@ -174,9 +174,13 @@ fi convertit în cuvinte (abs(%s) > %s)."
         if len(text) > 1:
             forms = [text[0], text[0][:-1] + text[1], "de " + text[0][:-1] + text[1]]
             result = self.pluralize(side_effect, forms)
-        # mega inflections are different
+        # mega inflections also need de/no-de pluralization
+        # (e.g. 33 milioane → 33 de milioane). The giga path is already
+        # handled above because GIGA_SUFFIX is declared with a "/" form.
         if side_effect > 1 and result.endswith(self.MEGA_SUFFIX):
-            result = result.replace(self.MEGA_SUFFIX, self.MEGA_SUFFIX_I)
+            inflected = result.replace(self.MEGA_SUFFIX, self.MEGA_SUFFIX_I)
+            forms = [result, inflected, "de " + inflected]
+            result = self.pluralize(side_effect, forms)
         elif side_effect > 1 and result.endswith("iliare"):
             result = result.replace("iliare", self.GIGA_SUFFIX_I)
         return result

--- a/tests/lang/test_ro.py
+++ b/tests/lang/test_ro.py
@@ -51,7 +51,9 @@ class Num2WordsROTest(TestCase):
     def test_big_numbers(self):
         self.assertEqual(num2words(1000000, lang="ro"), "un milion")
         self.assertEqual(num2words(1000000000, lang="ro"), "un miliard")
-        self.assertEqual(num2words(33000000, lang="ro"), "treizeci și trei milioane")
+        self.assertEqual(
+            num2words(33000000, lang="ro"), "treizeci și trei de milioane"
+        )
         self.assertEqual(
             num2words(247000000000, lang="ro"),
             "două sute patruzeci și șapte de miliarde",
@@ -96,8 +98,8 @@ class Num2WordsROTest(TestCase):
         )
         self.assertEqual(
             num2words(123456789, lang="ro", to="currency"),
-            "una sută douăzeci și trei milioane patru sute cincizeci și șase de mii "
-            "șapte sute optzeci și nouă de lei",
+            "una sută douăzeci și trei de milioane patru sute cincizeci și șase "
+            "de mii șapte sute optzeci și nouă de lei",
         )
 
     def test_to_year(self):
@@ -130,7 +132,8 @@ class Num2WordsROTest(TestCase):
             num2words(1, lang="ro", to="year", suffix="d.Hr."), "unu d.Hr."
         )
         self.assertEqual(
-            num2words(-66000000, lang="ro", to="year"), "șaizeci și șase milioane î.Hr."
+            num2words(-66000000, lang="ro", to="year"),
+            "șaizeci și șase de milioane î.Hr.",
         )
 
     def test_negative_decimals(self):


### PR DESCRIPTION
Ports [savoirfairelinux/num2words#499](https://github.com/savoirfairelinux/num2words/pull/499) by @adrian-branescu (fixes upstream #498).

## Summary

Romanian grammar inserts the connector **"de"** between a multiplier ≥ 20 and the noun it counts. num2words2 already did this for *thousand* and *miliard* (the giga path), but the *milion* (mega) path only swapped suffixes without adding "de":

| Input | Before | After |
|---|---|---|
| 33000000 | treizeci și trei **milioane** | treizeci și trei **de milioane** |
| 247000000 | două sute patruzeci și șapte **milioane** | două sute patruzeci și șapte **de milioane** |
| -66000000 (year) | șaizeci și șase **milioane** î.Hr. | șaizeci și șase **de milioane** î.Hr. |

The miliard path was already correct (\`33000000000 → "treizeci și trei de miliarde"\`) because \`GIGA_SUFFIX\` is declared with the "/" form that triggers the existing pluralize block.

## Test plan

- [x] All 8 RO tests still green (3 expectations updated to match the new correct output, the rest unchanged)
- [x] Million scale: 33000000, 247000000 now include "de"
- [x] Milliard scale: still produces "de miliarde" correctly (no double-"de" regression)
- [x] Edge cases: 1000000 → "un milion" (no plural form, no "de"), 2000000 → "două milioane" (plural but < 20, no "de")

## Fix vs. original upstream

Upstream's patch unconditionally re-ran pluralize for both mega and giga paths, which would double-prefix "de" because num2words2's giga handling already pluralizes via the "iliard/e" slash-form. This port only re-runs pluralize on the mega branch, where it's actually needed — the giga branch is left untouched.

## Credit
Original author: @adrian-branescu.

Original upstream PR: https://github.com/savoirfairelinux/num2words/pull/499

🤖 Generated with [Claude Code](https://claude.com/claude-code)