### PR TITLE
Port: Arabic — YER and USD currency forms [upstream #563]

### DIFF
--- a/num2words2/lang_AR.py
+++ b/num2words2/lang_AR.py
@@ -38,6 +38,14 @@ CURRENCY_LBP = [
     ("ليرة", "ليرتان", "ليرات", "ليرة"),
     ("قرش", "قرشان", "قروش", "قرش"),
 ]
+CURRENCY_YER = [
+    ("ريال", "ريالان", "ريالات", "ريالاً"),
+    ("فلس", "فلسان", "فلس", "فلس"),
+]
+CURRENCY_USD = [
+    ("دولار", "دولارين", "دولارات", "دولاراً"),
+    ("سنت", "سنتان", "سنتا", "سنتاٌ"),
+]
 CURRENCY_TND = [
     ("دينار", "ديناران", "دينارات", "ديناراً"),
     ("مليماً", "ميلمان", "مليمات", "مليم"),
@@ -502,6 +510,14 @@ class Num2Word_AR(Num2Word_Base):
         elif currency == "LBP":
             self.currency_unit = CURRENCY_LBP[0]
             self.currency_subunit = CURRENCY_LBP[1]
+            self.partPrecision = 2
+        elif currency == "YER":
+            self.currency_unit = CURRENCY_YER[0]
+            self.currency_subunit = CURRENCY_YER[1]
+            self.partPrecision = 2
+        elif currency == "USD":
+            self.currency_unit = CURRENCY_USD[0]
+            self.currency_subunit = CURRENCY_USD[1]
             self.partPrecision = 2
         else:
             self.currency_unit = CURRENCY_SR[0]


### PR DESCRIPTION
Ports [savoirfairelinux/num2words#563](https://github.com/savoirfairelinux/num2words/pull/563) by @mf0wzi.

## Summary

Adds two new currency-preference branches to \`lang_AR\`'s \`set_currency_prefer\`:

- **YER** (Yemeni Rial / ريال يمني) — sub-unit fils (فلس)
- **USD** (US Dollar) — sub-unit cent (سنت)

Each ships with the standard four-form Arabic case declension (singular, dual, plural, accusative).

## Test plan

- [x] All 9 existing AR tests still green
- [x] \`123.45 YER\` → "مائة وثلاثة وعشرون ريالاً وخمس وأربعون فلس"
- [x] \`123.45 USD\` → "مائة وثلاثة وعشرون دولاراً وخمس وأربعون سنتاٌ"

## Credit
Original author: @mf0wzi.

Original upstream PR: https://github.com/savoirfairelinux/num2words/pull/563

🤖 Generated with [Claude Code](https://claude.com/claude-code)