### PR TITLE
ci+docs: credit upstream contributors in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,30 @@ jobs:
             git log --pretty=format:'- %s (%h)' "${TAG}" | head -50
           fi
 
+          # Surface upstream contributor credits — extract any
+          # "savoirfairelinux/num2words#NNN by @user" mentions from commit
+          # bodies so original authors are visible in the release notes.
+          if [ -n "${PREV_TAG}" ]; then
+            range="${PREV_TAG}..${TAG}"
+          else
+            range="${TAG}"
+          fi
+          credits=$(git log --pretty=format:'%B' "${range}" \
+            | grep -oE 'savoirfairelinux/num2words#[0-9]+ by @[A-Za-z0-9_-]+' \
+            | sort -u || true)
+          if [ -n "${credits}" ]; then
+            echo
+            echo "## Credits"
+            echo
+            echo "Thank you to the upstream contributors whose work this release ports:"
+            echo
+            while IFS= read -r line; do
+              upstream_pr=$(echo "$line" | grep -oE '#[0-9]+' | tr -d '#')
+              author=$(echo "$line" | grep -oE '@[A-Za-z0-9_-]+')
+              echo "- ${author} — [savoirfairelinux/num2words#${upstream_pr}](https://github.com/savoirfairelinux/num2words/pull/${upstream_pr})"
+            done <<<"${credits}"
+          fi
+
           echo
           echo "## Languages Supported"
           echo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+# Contributing to num2words2
+
+`num2words2` is an actively-maintained, independent fork of `savoirfairelinux/num2words`. Contributions are welcome here directly — open issues and pull requests against [`jqueguiner/num2words2`](https://github.com/jqueguiner/num2words2), not the upstream repo.
+
+If you have an upstream PR that's been waiting for attention, feel free to open an equivalent PR here and reference the original — we'll port it with full credit to you.
+
 ## How can I contribute ?
 
 ### Code contribution
@@ -5,7 +11,7 @@
 #### Issues
 
 If you are unsure where to begin contribution to Num2Words, you can start by looking through the issues page.
-Numerous issues are created and waiting for your love on the [issue board](https://github.com/savoirfairelinux/num2words/issues).
+Numerous issues are created and waiting for your love on the [issue board](https://github.com/jqueguiner/num2words2/issues).
 
 #### Pull Requests
 
@@ -13,7 +19,7 @@ Contributions will be accepted through the creation of Pull Requests. Here is th
 
 * Fork the repository into yours and work from there
 * Commit and push your changes into your fork
-* When you are done, create a [Pull Request](https://github.com/savoirfairelinux/num2words/compare) on the **master** branch
+* When you are done, create a [Pull Request](https://github.com/jqueguiner/num2words2/compare) on the **master** branch
 
 A template is provided to create your Pull Request. Try to fill the information at the best of your knowledge.
 


### PR DESCRIPTION
Two small follow-ups now that v1.0.2 has shipped and we've started receiving outside contributions.

## 1. Release-notes contributor credits

\`release.yml\` now scans commit bodies in the tag range for \`savoirfairelinux/num2words#NNN by @user\` patterns and adds a **Credits** section to the GitHub Release listing each upstream contributor with a link back to their original PR. v1.0.2 already shipped without this — every future tag picks it up.

## 2. CONTRIBUTING.md no longer points to upstream

- Adds a top-of-file note clarifying that num2words2 is an actively-maintained independent fork
- Replaces the stale \`savoirfairelinux/num2words\` URLs with \`jqueguiner/num2words2\`
- Issues are now enabled on this repo (was off by default for forks)

## Still TODO (manual)

The repo is still flagged as a fork of \`savoirfairelinux/num2words\`. To fully separate so contributors land here naturally:

1. Visit https://github.com/jqueguiner/num2words2/settings
2. Scroll to **Danger Zone**
3. Click **"Leave fork network"**

This is a one-click action GitHub doesn't expose via API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)