### PR TITLE
Add cz/dk legacy aliases for Czech/Danish

### DIFF
--- a/num2words2/__init__.py
+++ b/num2words2/__init__.py
@@ -355,6 +355,8 @@ CONVERTER_CLASSES = {
     "nb": lang_NO.Num2Word_NO(),  # Alias for Norwegian Bokmål
     "jv": lang_JW.Num2Word_JW(),  # Alias for Javanese (modern ISO 639-1)
     "miz": lang_LUS.Num2Word_LUS(),  # Alias for Mizo
+    "cz": lang_CS.Num2Word_CS(),  # Pre-ISO-639 code for Czech (ISO is 'cs')
+    "dk": lang_DA.Num2Word_DA(),  # Pre-ISO-639 code for Danish (ISO is 'da')
 }
 
 CONVERTES_TYPES = ["cardinal", "ordinal", "ordinal_num", "year", "currency"]

--- a/tests/lang/test_legacy_aliases.py
+++ b/tests/lang/test_legacy_aliases.py
@@ -1,0 +1,34 @@
+# Tests for legacy pre-ISO-639 language aliases.
+#
+# Refs:
+#   savoirfairelinux/num2words#431 (cz -> cs)
+#   savoirfairelinux/num2words#425 (dk -> da)
+import unittest
+
+from num2words2 import num2words
+
+
+class LegacyAliasTest(unittest.TestCase):
+    def test_cz_alias_routes_to_cs(self):
+        self.assertEqual(num2words(5, lang="cz"), num2words(5, lang="cs"))
+        self.assertEqual(num2words(1.5, lang="cz"), num2words(1.5, lang="cs"))
+
+    def test_dk_alias_routes_to_da(self):
+        self.assertEqual(num2words(5, lang="dk"), num2words(5, lang="da"))
+        self.assertEqual(
+            num2words(1829794, lang="dk"), num2words(1829794, lang="da")
+        )
+
+    def test_cz_no_longer_raises(self):
+        # Previously raised NotImplementedError. Pre-ISO-639 callers had to
+        # remap to "cs" themselves; this is the upstream pain point in #431.
+        try:
+            num2words(5, lang="cz")
+        except NotImplementedError:  # pragma: no cover - regression guard
+            self.fail("cz alias should not raise NotImplementedError")
+
+    def test_dk_no_longer_raises(self):
+        try:
+            num2words(5, lang="dk")
+        except NotImplementedError:  # pragma: no cover - regression guard
+            self.fail("dk alias should not raise NotImplementedError")


### PR DESCRIPTION
## Summary

- `lang='cz'` and `lang='dk'` previously raised `NotImplementedError`. Both now route to the existing Czech / Danish converters.
- ISO 639-1 codes `cs` and `da` continue to work unchanged.

## Refs

Fixes the user pain points reported in:
- savoirfairelinux/num2words#431 by @dmkyr20 — *Change CZ language code to CS*
- savoirfairelinux/num2words#425 by @dejurin — *AttributeError: 'Num2Word_DK' object has no attribute 'ordflag'*

## Test plan

- [x] `tests/lang/test_legacy_aliases.py` covers parity between cz↔cs and dk↔da
- [x] `tests/lang/test_cs.py` and `tests/lang/test_da.py` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)