### PR TITLE
tr: preserve leading zero in fractional decimals (e.g. 0.03)

### DIFF
--- a/num2words2/lang_TR.py
+++ b/num2words2/lang_TR.py
@@ -423,11 +423,16 @@ class Num2Word_TR(Num2Word_Base):
         self.to_splitnum(abs_value)
         wrd = ""
         wrd += self.pointword
-        if len(self.integers_to_read[1]) >= 1:
-            wrd += self.CARDINAL_TENS.get(self.integers_to_read[1][0], "")
-
-        if len(self.integers_to_read[1]) == 2:
-            wrd += self.CARDINAL_ONES.get(self.integers_to_read[1][1], "")
+        fractional = self.integers_to_read[1]
+        if len(fractional) == 2 and fractional[0] == "0" and fractional[1] != "0":
+            # Without this, 0.03 would drop its leading zero and read as 0.3.
+            wrd += self.ZERO
+            wrd += self.CARDINAL_ONES.get(fractional[1], "")
+        else:
+            if len(fractional) >= 1:
+                wrd += self.CARDINAL_TENS.get(fractional[0], "")
+            if len(fractional) == 2:
+                wrd += self.CARDINAL_ONES.get(fractional[1], "")
 
         if self.integers_to_read[0] == "0":
             wrd = self.ZERO + wrd

--- a/tests/lang/test_tr.py
+++ b/tests/lang/test_tr.py
@@ -232,14 +232,17 @@ class Num2WordsTRTest(TestCase):
         self.assertEqual(num2words(11.11, lang="tr"), "onbirvirgülonbir")
         self.assertEqual(num2words(20.2, lang="tr"), "yirmivirgülyirmi")
         self.assertEqual(num2words(99.99, lang="tr"), "doksandokuzvirgüldoksandokuz")
-        self.assertEqual(num2words(100.01, lang="tr"), "yüzvirgülbir")
+        self.assertEqual(num2words(100.01, lang="tr"), "yüzvirgülsıfırbir")
+        # Regression for savoirfairelinux/num2words#487 (leading zero in fractional).
+        self.assertEqual(num2words(0.03, lang="tr"), "sıfırvirgülsıfırüç")
+        self.assertEqual(num2words(0.05, lang="tr"), "sıfırvirgülsıfırbeş")
         self.assertEqual(num2words(100.5, lang="tr"), "yüzvirgülelli")
         self.assertEqual(num2words(123.45, lang="tr"), "yüzyirmiüçvirgülkırkbeş")
         self.assertEqual(num2words(1000.5, lang="tr"), "binvirgülelli")
         self.assertEqual(
             num2words(1234.56, lang="tr"), "binikiyüzotuzdörtvirgülellialtı"
         )
-        self.assertEqual(num2words(10000.01, lang="tr"), "onbinvirgülbir")
+        self.assertEqual(num2words(10000.01, lang="tr"), "onbinvirgülsıfırbir")
         self.assertEqual(num2words(-0.5, lang="tr"), "eksi sıfırvirgülelli")
         self.assertEqual(num2words(-1.5, lang="tr"), "eksi birvirgülelli")
         self.assertEqual(num2words(-10.5, lang="tr"), "eksi onvirgülelli")


### PR DESCRIPTION
## Summary

\`num2words(0.03, lang='tr')\` previously returned \`'sıfırvirgülüç'\` (silently dropping the leading zero — sounds like \`0.3\`). Now returns \`'sıfırvirgülsıfırüç'\`.

Before / after:

\`\`\`python
>>> num2words(0.03, lang='tr')   # was 'sıfırvirgülüç'
'sıfırvirgülsıfırüç'
>>> num2words(0.05, lang='tr')   # was 'sıfırvirgülbeş'
'sıfırvirgülsıfırbeş'
>>> num2words(100.01, lang='tr') # was 'yüzvirgülbir'
'yüzvirgülsıfırbir'
\`\`\`

Existing two-digit-fractional cases (e.g. \`0.5 → sıfırvirgülelli\`, \`1.5 → birvirgülelli\`) are unchanged.

## Refs

Fixes savoirfairelinux/num2words#487 by @Juan-hussain.

## Test plan

- [x] \`tests/lang/test_tr.py\` — 12 tests pass; 100.01 / 10000.01 expectations updated; new regression tests for 0.03 and 0.05

🤖 Generated with [Claude Code](https://claude.com/claude-code)