### PR TITLE
uk: accept all common gender aliases (f, ж, feminine, …)

### DIFF
--- a/num2words2/lang_UK.py
+++ b/num2words2/lang_UK.py
@@ -581,10 +581,14 @@ class Num2Word_UK(Num2Word_Base):
         else:
             morphological_case = 0
 
-        if "gender" in kwargs:
-            gender = kwargs["gender"] == "feminine"
-        else:
-            gender = False
+        # Accept the same gender aliases as lang_RU: short codes, English
+        # names, and Ukrainian/Russian Cyrillic names. Anything else falls
+        # back to masculine.
+        feminine_aliases = {"f", "feminine", "ж", "жіночий", "женский"}
+        gender_kw = kwargs.get("gender")
+        gender = (
+            isinstance(gender_kw, str) and gender_kw.lower() in feminine_aliases
+        )
 
         n = str(number).replace(",", ".")
         if "." in n:

--- a/tests/lang/test_uk.py
+++ b/tests/lang/test_uk.py
@@ -3440,3 +3440,21 @@ class Num2WordsUKTest(TestCase):
         self.assertEqual(
             num2words(-10.25, lang="uk"), "мінус десять кома двадцять п'ять"
         )
+
+
+class UkrainianGenderAliasTest:
+    pass
+
+
+def test_uk_gender_short_alias_feminine():
+    # Regression for savoirfairelinux/num2words#560 — gender='f' was ignored.
+    from num2words2 import num2words
+    assert num2words(21, lang="uk", gender="f") == "двадцять одна"
+    assert num2words(1, lang="uk", gender="f") == "одна"
+    assert num2words(21, lang="uk", gender="ж") == "двадцять одна"
+    assert num2words(21, lang="uk", gender="feminine") == "двадцять одна"
+
+
+def test_uk_gender_default_is_masculine():
+    from num2words2 import num2words
+    assert num2words(21, lang="uk") == "двадцять один"


### PR DESCRIPTION
## Summary

\`num2words(21, lang='uk', gender='f')\` previously returned the masculine \`'двадцять один'\` because only the literal string \`'feminine'\` was matched. This PR widens the alias set to cover the same forms accepted by \`lang_RU\`.

\`\`\`python
>>> num2words(21, lang='uk', gender='f')
'двадцять одна'
>>> num2words(21, lang='uk', gender='ж')
'двадцять одна'
>>> num2words(21, lang='uk', gender='feminine')
'двадцять одна'
>>> num2words(21, lang='uk')                # default unchanged
'двадцять один'
\`\`\`

## Refs

Fixes savoirfairelinux/num2words#560 by @fo-bo.

## Test plan

- [x] All existing \`tests/lang/test_uk.py\` pass
- [x] New regression tests for \`gender='f'\`, \`gender='ж'\`, \`gender='feminine'\`, and default-is-masculine

🤖 Generated with [Claude Code](https://claude.com/claude-code)