### PR TITLE
es: apocopate 'uno' to 'un' before mil/millones

### DIFF
--- a/num2words2/lang_ES.py
+++ b/num2words2/lang_ES.py
@@ -353,6 +353,14 @@ class Num2Word_ES(Num2Word_EUR):
                 ctext = "nove"
             ntext += "t" + self.gender_stem + "s"
         else:
+            # Spanish drops the final 'o' of 'uno' (and adds an accent in
+            # 'veintiuno') before any noun like 'mil' or 'millones':
+            # 31000 -> "treinta y un mil", 21000 -> "veintiún mil".
+            if nnum >= 1000:
+                if ctext.endswith("veintiuno"):
+                    ctext = ctext[:-3] + "ún"
+                elif ctext.endswith("uno"):
+                    ctext = ctext[:-1]
             ntext = " " + ntext
 
         return (ctext + ntext, cnum * nnum)

--- a/tests/lang/test_es.py
+++ b/tests/lang/test_es.py
@@ -2758,3 +2758,27 @@ class Num2WordsESTest(TestCase):
         self.assertEqual(num2words(-1.4, lang="es"), "menos uno punto cuatro")
         self.assertEqual(num2words(-10.25, lang="es"), "menos diez punto dos cinco")
         self.assertEqual(num2words(-0.001, lang="es"), "menos cero punto cero cero uno")
+
+
+# Regression tests for savoirfairelinux/num2words#515 — "uno mil" elision.
+
+def test_es_uno_elides_to_un_before_mil():
+    from num2words2 import num2words
+    assert num2words(31000, lang="es") == "treinta y un mil"
+    assert num2words(101300, lang="es") == "ciento un mil trescientos"
+    assert num2words(891003, lang="es") == "ochocientos noventa y un mil tres"
+
+
+def test_es_veintiuno_elides_to_veintiun_before_mil_or_millones():
+    from num2words2 import num2words
+    assert num2words(21000, lang="es") == "veintiún mil"
+    assert num2words(21000000, lang="es") == "veintiún millones"
+
+
+def test_es_uno_intact_when_terminal():
+    from num2words2 import num2words
+    # The elision must not fire for terminal "uno" — these stay intact.
+    assert num2words(1, lang="es") == "uno"
+    assert num2words(21, lang="es") == "veintiuno"
+    assert num2words(31, lang="es") == "treinta y uno"
+    assert num2words(101, lang="es") == "ciento uno"


### PR DESCRIPTION
## Summary

Spanish drops the final \`o\` of \`uno\` (and adds an accent on \`veintiuno\` → \`veintiún\`) when the number is followed by a noun like \`mil\` or \`millones\`. The previous output was ungrammatical:

| n | Was | Now |
|---|-----|-----|
| 31000 | treinta y \`uno\` mil | treinta y \`un\` mil |
| 101300 | ciento \`uno\` mil trescientos | ciento \`un\` mil trescientos |
| 891003 | … noventa y \`uno\` mil tres | … noventa y \`un\` mil tres |
| 21000 | veintiuno mil | veintiún mil |
| 21000000 | veintiuno millones | veintiún millones |

Terminal \`uno\` (\`1\`, \`21\`, \`31\`, \`101\`, …) is unchanged.

## Refs

Fixes savoirfairelinux/num2words#515 by @German105.

## Test plan

- [x] All 1232 existing \`tests/lang/test_es*.py\` cases pass
- [x] New regression tests for \`uno → un\` and \`veintiuno → veintiún\` elision
- [x] Confirms terminal \`uno\` is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)