### PR TITLE
ru: default currency to RUB (рубли / копейки)

### DIFF
--- a/num2words2/lang_RU.py
+++ b/num2words2/lang_RU.py
@@ -466,7 +466,7 @@ class Num2Word_RU(Num2Word_Base):
         return forms[2]
 
     def to_currency(
-        self, val, currency="EUR", cents=True, separator=",", adjective=False
+        self, val, currency="RUB", cents=True, separator=",", adjective=False
     ):
         # Handle scientific notation that results in whole numbers
         # (e.g., 1e+18 becomes 1000000000000000000.0)

--- a/tests/lang/test_ru.py
+++ b/tests/lang/test_ru.py
@@ -404,3 +404,19 @@ class Num2WordsRUTest(TestCase):
         self.assertEqual(
             num2words(-10.25, lang="ru"), "минус десять целых двадцать пять сотых"
         )
+
+
+def test_ru_currency_defaults_to_rub():
+    # Regression for savoirfairelinux/num2words#483 — RU default currency.
+    from num2words2 import num2words
+    assert num2words(5, lang="ru", to="currency") == "пять рублей"
+    assert (
+        num2words(5.20, lang="ru", to="currency")
+        == "пять рублей, двадцать копеек"
+    )
+    # Explicit currency overrides still work.
+    assert num2words(5, lang="ru", to="currency", currency="EUR") == "пять евро"
+    assert (
+        num2words(5.20, lang="ru", to="currency", currency="USD")
+        == "пять долларов, двадцать центов"
+    )


### PR DESCRIPTION
## Summary

\`num2words(5.20, lang='ru', to='currency')\` returned \`'пять евро, двадцать центов'\` because the default was inherited from EUR. Russian now defaults to RUB.

\`\`\`python
>>> num2words(5, lang='ru', to='currency')
'пять рублей'
>>> num2words(5.20, lang='ru', to='currency')
'пять рублей, двадцать копеек'
\`\`\`

Explicit \`currency=\` overrides still work.

## Refs

Fixes savoirfairelinux/num2words#483 by @ocmarus.

## Test plan

- [x] All 11 existing \`tests/lang/test_ru.py\` cases pass
- [x] New regression: default = rubles/kopecks; \`currency='EUR'\` and \`'USD'\` overrides preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)