### PR TITLE
am: drop Latin prefix bleeding into high-order words

### DIFF
--- a/num2words2/lang_AM.py
+++ b/num2words2/lang_AM.py
@@ -31,13 +31,26 @@ class Num2Word_AM(lang_EUR.Num2Word_EUR):
     MEGA_SUFFIX = "ሚሊዮን"
 
     def set_high_numwords(self, high):
-        cap = 3 * (len(high) + 1)
-
-        for word, n in zip(high, range(cap, 5, -3)):
-            if n == 9:
-                self.cards[10**n] = word + self.GIGA_SUFFIX
-            else:
-                self.cards[10**n] = word + self.MEGA_SUFFIX
+        # The inherited EUR routine prepends a Latin prefix ("m", "b",
+        # "tr", …) to the Ethiopic suffix, producing mixed-script tokens
+        # like "trሚሊዮን" or "mሚሊዮን" — visible to users as a stray Latin
+        # letter sitting before each big-number word. Replace with proper
+        # Amharic transliterations.
+        self.cards.clear()
+        self.cards.update(
+            {
+                10 ** 33: "ዴሲሊዮን",
+                10 ** 30: "ኖኒሊዮን",
+                10 ** 27: "ኦክቲሊዮን",
+                10 ** 24: "ሴፕቲሊዮን",
+                10 ** 21: "ሴክስቲሊዮን",
+                10 ** 18: "ኲንቲሊዮን",
+                10 ** 15: "ኳድሪሊዮን",
+                10 ** 12: "ትሪሊዮን",
+                10 ** 9: self.GIGA_SUFFIX,
+                10 ** 6: self.MEGA_SUFFIX,
+            }
+        )
 
     def setup(self):
         super(Num2Word_AM, self).setup()

--- a/tests/lang/test_am.py
+++ b/tests/lang/test_am.py
@@ -87,3 +87,16 @@ class TestAM(LangTest, TestCase):
                 "00000000000000000000000000000000",
                 lang="am",
             )
+
+
+def test_am_no_latin_prefix_in_high_words():
+    # Regression for savoirfairelinux/num2words#591 — stray Latin "m"
+    # appeared between thousands and "ሚሊዮን" in big numbers.
+    from num2words2 import num2words
+    out = num2words(568476685, lang="am")
+    # No ASCII letters allowed; everything must be Ethiopic + spaces.
+    assert all(c.isspace() or not c.isascii() for c in out), out
+    assert "ሚሊዮን" in out
+    out_b = num2words(1_000_000_000, lang="am")
+    assert "ቢሊዮን" in out_b
+    assert "b" not in out_b.lower()


### PR DESCRIPTION
## Summary

Inheriting \`Num2Word_EUR.set_high_numwords\` was producing mixed-script outputs because the EUR routine prepends a Latin prefix (\`m\`, \`b\`, \`tr\`, …) to whatever \`MEGA_SUFFIX\` / \`GIGA_SUFFIX\` is configured. In Amharic that meant \`mሚሊዮን\`, \`bቢሊዮን\`, \`trሚሊዮን\`, etc.

Before:

\`\`\`python
>>> num2words(568476685, lang='am')
'አምስት መቶ ስድሳ ስምንት mሚሊዮን አራት መቶ ሰባ ስድስት ሺህ ስድስት መቶ ሰማንያ አምስት'
\`\`\`

After:

\`\`\`python
>>> num2words(568476685, lang='am')
'አምስት መቶ ስድሳ ስምንት ሚሊዮን አራት መቶ ሰባ ስድስት ሺህ ስድስት መቶ ሰማንያ አምስት'
\`\`\`

Override now sets \`10**6\` through \`10**33\` to clean Amharic transliterations.

## Refs

Fixes savoirfairelinux/num2words#591 by @ZacharyOuellet.

## Test plan

- [x] All 7 existing \`tests/lang/test_am.py\` pass (one previously-skipped case unchanged)
- [x] New regression test asserts no ASCII letters appear in the output and confirms ሚሊዮን / ቢሊዮን are still emitted
- [x] Spot-checked 1, 100, 1000, 1802, 1210, 568476685, 10⁶, 10⁹

🤖 Generated with [Claude Code](https://claude.com/claude-code)