### PR TITLE
id: implement str_to_number for string input

### DIFF
--- a/num2words2/lang_ID.py
+++ b/num2words2/lang_ID.py
@@ -62,6 +62,13 @@ class Num2Word_ID:
     errmsg_toobig = "Number is too large to convert to words (abs(%s) > %s)."
     MAXVAL = 10**36
 
+    def str_to_number(self, value):
+        # Num2Word_ID does not inherit from Num2Word_Base, so it lacks the
+        # default str_to_number used by num2words() when given a string input.
+        from decimal import Decimal
+
+        return Decimal(value)
+
     def split_by_koma(self, number):
         return str(number).split(".")
 

--- a/tests/lang/test_id.py
+++ b/tests/lang/test_id.py
@@ -60,3 +60,12 @@ class Num2WordsIDTest(TestCase):
         self.assertEqual(num2words(-0.5, lang="id"), "min nol koma lima")
         self.assertEqual(num2words(-1.4, lang="id"), "min satu koma empat")
         self.assertEqual(num2words(-10.25, lang="id"), "min sepuluh koma dua lima")
+
+
+def test_id_str_to_number_does_not_raise():
+    # Regression for savoirfairelinux/num2words#476 — Num2Word_ID was
+    # missing str_to_number and crashed on string input.
+    from num2words2 import num2words
+    assert num2words("5", lang="id") == "lima"
+    assert num2words("1234", lang="id") == "seribu dua ratus tiga puluh empat"
+    assert num2words("5.5", lang="id") == "lima koma lima"


### PR DESCRIPTION
## Summary

\`Num2Word_ID\` does not inherit from \`Num2Word_Base\`, so it was missing the default \`str_to_number\` method that \`num2words()\` calls when given a string. The previous behavior:

\`\`\`python
>>> num2words('5', lang='id')
AttributeError: 'Num2Word_ID' object has no attribute 'str_to_number'
\`\`\`

After:

\`\`\`python
>>> num2words('5', lang='id')
'lima'
>>> num2words('1234', lang='id')
'seribu dua ratus tiga puluh empat'
>>> num2words('5.5', lang='id')
'lima koma lima'
\`\`\`

## Refs

Fixes savoirfairelinux/num2words#476 by @auahelap.

## Test plan

- [x] All existing \`tests/lang/test_id.py\` pass
- [x] New regression test confirms string inputs no longer raise

🤖 Generated with [Claude Code](https://claude.com/claude-code)