### PR TITLE
ci: drop manual workflow_dispatch from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ on:
     branches:
       - master
       - main
-  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Releases are tag-driven; the manual trigger was a hangover from when multiple publish workflows existed. Removing it so a non-tagged manual run can't accidentally publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)