### PR TITLE
fr: drop trailing 's' of 'cents'/'vingts' before -ième

### DIFF
--- a/num2words2/lang_FR.py
+++ b/num2words2/lang_FR.py
@@ -124,6 +124,10 @@ class Num2Word_FR(Num2Word_EUR):
         else:
             if word[-1] == "e":
                 word = word[:-1]
+            # Drop the trailing 's' of 'cents' / 'vingts' before -ième:
+            # 200 -> "deux centième" (not "deux centsième").
+            if word.endswith("ts") or word.endswith("ents"):
+                word = word[:-1]
             word = word + "ième"
         return word
 

--- a/tests/lang/test_fr.py
+++ b/tests/lang/test_fr.py
@@ -200,3 +200,14 @@ class Num2WordsFRTest(TestCase):
         self.assertEqual(num2words(-0.04, lang="fr"), "moins zéro virgule zéro quatre")
         self.assertEqual(num2words(-1.4, lang="fr"), "moins un virgule quatre")
         self.assertEqual(num2words(-10.25, lang="fr"), "moins dix virgule deux cinq")
+
+
+def test_fr_ordinal_drops_trailing_s_of_cents_and_vingts():
+    # Regression for num2words2#65 (ports savoirfairelinux/num2words#409).
+    from num2words2 import num2words
+    assert num2words(200, lang="fr", to="ordinal") == "deux centième"
+    assert num2words(80, lang="fr", to="ordinal") == "quatre-vingtième"
+    assert num2words(280, lang="fr", to="ordinal") == "deux cent quatre-vingtième"
+    # Non-cents/vingts words unaffected
+    assert num2words(3, lang="fr", to="ordinal") == "troisième"
+    assert num2words(100, lang="fr", to="ordinal") == "centième"


### PR DESCRIPTION
Closes #65 (ports savoirfairelinux/num2words#409 by @m-f-h).

```python
>>> num2words(200, lang='fr', to='ordinal')
'deux centième'   # was 'deux centsième'
>>> num2words(80, lang='fr', to='ordinal')
'quatre-vingtième' # was 'quatre-vingtsième'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)