### PR TITLE
no: use neuter 'ett' before 'hundre'

### DIFF
--- a/num2words2/lang_NO.py
+++ b/num2words2/lang_NO.py
@@ -116,11 +116,13 @@ class Num2Word_NO(lang_EUR.Num2Word_EUR):
         elif lnum >= 100 > rnum:
             return ("%s og %s" % (ltext, rtext), lnum + rnum)
         elif rnum > lnum:
-            # Special case for Norwegian: use "ett" before "tusen" but not "en" before "hundre"
-            if lnum == 1 and rnum == 1000:
+            # Norwegian Bokmål: 'hundre' and 'tusen' are neuter nouns, so the
+            # numeral 1 takes the neuter form 'ett' (not 'en'). Issue #58
+            # ports savoirfairelinux/num2words#485.
+            if lnum == 1 and rnum in (100, 1000):
                 return ("ett %s" % rtext, lnum * rnum)
             elif lnum == 100 and rnum == 1000:
-                # 100000 should be "hundre tusen" not "en hundre tusen"
+                # 100000 should be "hundre tusen" not "ett hundre tusen"
                 return ("hundre tusen", 100000)
             # Handle Norwegian plural forms for million and milliard
             if rnum == 10**6:

--- a/tests/lang/test_no.py
+++ b/tests/lang/test_no.py
@@ -60,7 +60,7 @@ class Num2WordsNOTest(TestCase):
         self.assertEqual(num2words(14, to="ordinal", lang="no"), "fjortende")
         self.assertEqual(num2words(30, to="ordinal", lang="no"), "trettiende")
         self.assertEqual(num2words(32, to="ordinal", lang="no"), "trettiandre")
-        self.assertEqual(num2words(100, to="ordinal", lang="no"), "en hundrede")
+        self.assertEqual(num2words(100, to="ordinal", lang="no"), "ett hundrede")
         self.assertEqual(num2words(1000, to="ordinal", lang="no"), "ett tusende")
         self.assertEqual(
             num2words(1435, to="ordinal", lang="no"),
@@ -88,11 +88,11 @@ class Num2WordsNOTest(TestCase):
             num2words(2.50, to="currency", lang="no"), "to kroner og femti øre"
         )
         self.assertEqual(
-            num2words(135, to="currency", lang="no"), "en hundre og trettifem kroner"
+            num2words(135, to="currency", lang="no"), "ett hundre og trettifem kroner"
         )
         self.assertEqual(
             num2words(135.59, to="currency", lang="no"),
-            "en hundre og trettifem kroner og femtini øre",
+            "ett hundre og trettifem kroner og femtini øre",
         )
 
     def test_negative_decimals(self):


### PR DESCRIPTION
Closes #58 (ports savoirfairelinux/num2words#485 by @gealodge).

```python
>>> num2words(100, lang='no')
'ett hundre'   # was 'en hundre'
>>> num2words(1000, lang='no')
'ett tusen'    # unchanged
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)