### PR TITLE
ca: decimal separator 'coma' + integer fractional reading

### DIFF
--- a/num2words2/lang_CA.py
+++ b/num2words2/lang_CA.py
@@ -216,7 +216,7 @@ class Num2Word_CA(Num2Word_EUR):
         lows = ["quadr", "tr", "b", "m"]
         self.high_numwords = self.gen_high_numwords([], [], lows)
         self.negword = "menys "
-        self.pointword = "punt"
+        self.pointword = "coma"
         self.errmsg_nonnum = "type(%s) no és [long, int, float]"
         self.errmsg_floatord = "El float %s no pot ser tractat com un" " ordinal."
         self.errmsg_negord = (
@@ -224,7 +224,7 @@ class Num2Word_CA(Num2Word_EUR):
         )
         self.errmsg_toobig = "abs(%s) ha de ser inferior a %s."
         self.gender_stem = "è"
-        self.exclude_title = ["i", "menys", "punt"]
+        self.exclude_title = ["i", "menys", "coma"]
 
         self.mid_numwords = [
             (1000, "mil"),
@@ -395,6 +395,28 @@ class Num2Word_CA(Num2Word_EUR):
         else:
             ntext = " " + ntext
         return (ctext + ntext, cnum * nnum)
+
+    def to_cardinal_float(self, value):
+        # Catalan reads the fractional part as one integer (with leading zeros
+        # spelled out). 42.15 -> "quaranta-dos coma quinze", not "... un cinc".
+        # Issue #57; ports savoirfairelinux/num2words#631.
+        try:
+            float(value) == value
+        except (ValueError, TypeError):
+            raise TypeError(self.errmsg_nonnum % value)
+        pre, post = self.float2tuple(float(value))
+        post_str = str(post)
+        leading_zeros = self.precision - len(post_str)
+        post_str = "0" * leading_zeros + post_str
+        out = [self.to_cardinal(pre)]
+        if value < 0 and pre == 0:
+            out = [self.negword.strip()] + out
+        out.append(self.title(self.pointword))
+        for _ in range(leading_zeros):
+            out.append(self.to_cardinal(0))
+        if int(post_str) > 0 or leading_zeros == 0:
+            out.append(self.to_cardinal(int(post_str)))
+        return " ".join(out)
 
     def to_ordinal(self, value):
         self.verify_ordinal(value)

--- a/tests/lang/test_ca.py
+++ b/tests/lang/test_ca.py
@@ -8,23 +8,23 @@ TEST_CASES_CARDINAL = (
     (1, "un"),
     (2, "dos"),
     (3, "tres"),
-    (5.5, "cinc punt cinc"),
+    (5.5, "cinc coma cinc"),
     (11, "onze"),
     (12, "dotze"),
     (16, "setze"),
-    (17.42, "disset punt quatre dos"),
+    (17.42, "disset coma quaranta-dos"),
     (19, "dinou"),
     (20, "vint"),
     (21, "vint-i-un"),
     (26, "vint-i-sis"),
-    (27.312, "vint-i-set punt tres un dos"),
+    (27.312, "vint-i-set coma tres-cents dotze"),
     (28, "vint-i-vuit"),
     (30, "trenta"),
     (31, "trenta-un"),
     (40, "quaranta"),
     (44, "quaranta-quatre"),
     (50, "cinquanta"),
-    (53.486, "cinquanta-tres punt quatre vuit sis"),
+    (53.486, "cinquanta-tres coma quatre-cents vuitanta-sis"),
     (55, "cinquanta-cinc"),
     (60, "seixanta"),
     (67, "seixanta-set"),
@@ -37,7 +37,7 @@ TEST_CASES_CARDINAL = (
     (199, "cent noranta-nou"),
     (203, "dos-cents tres"),
     (287, "dos-cents vuitanta-set"),
-    (300.42, "tres-cents punt quatre dos"),
+    (300.42, "tres-cents coma quaranta-dos"),
     (356, "tres-cents cinquanta-sis"),
     (400, "quatre-cents"),
     (434, "quatre-cents trenta-quatre"),
@@ -58,7 +58,7 @@ TEST_CASES_CARDINAL = (
     (2385, "dos mil tres-cents vuitanta-cinc"),
     (3766, "tres mil set-cents seixanta-sis"),
     (4196, "quatre mil cent noranta-sis"),
-    (4196.42, "quatre mil cent noranta-sis punt quatre dos"),
+    (4196.42, "quatre mil cent noranta-sis coma quaranta-dos"),
     (5846, "cinc mil vuit-cents quaranta-sis"),
     (6459, "sis mil quatre-cents cinquanta-nou"),
     (7232, "set mil dos-cents trenta-dos"),
@@ -183,7 +183,7 @@ class TestNum2WordsCA(TestCase):
 
     def test_negative_decimals(self):
         # Comprehensive test for negative decimals including -0.4
-        self.assertEqual(num2words(-0.4, lang="ca"), "menys zero punt quatre")
-        self.assertEqual(num2words(-0.5, lang="ca"), "menys zero punt cinc")
-        self.assertEqual(num2words(-1.4, lang="ca"), "menys un punt quatre")
-        self.assertEqual(num2words(-10.25, lang="ca"), "menys deu punt dos cinc")
+        self.assertEqual(num2words(-0.4, lang="ca"), "menys zero coma quatre")
+        self.assertEqual(num2words(-0.5, lang="ca"), "menys zero coma cinc")
+        self.assertEqual(num2words(-1.4, lang="ca"), "menys un coma quatre")
+        self.assertEqual(num2words(-10.25, lang="ca"), "menys deu coma vint-i-cinc")


### PR DESCRIPTION
Closes #57 (ports savoirfairelinux/num2words#631 by @francesc-rambla).

```python
>>> num2words(42.15, lang='ca')
'quaranta-dos coma quinze'   # was 'quaranta-dos punt un cinc'
>>> num2words(0.05, lang='ca')
'zero coma zero cinc'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)