### PR TITLE
en: fall back to sentence converter for mixed text+numerals

### DIFF
--- a/num2words2/__init__.py
+++ b/num2words2/__init__.py
@@ -17,6 +17,8 @@
 
 from __future__ import unicode_literals
 
+import decimal
+
 from . import (
     lang_AF,
     lang_AM,
@@ -387,7 +389,14 @@ def num2words(number, ordinal=False, lang="en", to="cardinal", **kwargs):
     converter = CONVERTER_CLASSES[lang]
 
     if isinstance(number, str):
-        number = converter.str_to_number(number)
+        # If the string is a mix of text and numerals (e.g. "text 1"),
+        # route to num2words_sentence which extracts numerals and
+        # converts each in place. Issue #61 ports
+        # savoirfairelinux/num2words#281.
+        try:
+            number = converter.str_to_number(number)
+        except (decimal.InvalidOperation, ValueError):
+            return num2words_sentence(number, lang=lang, to=to, **kwargs)
 
     # backwards compatible
     if ordinal:

--- a/tests/lang/test_en.py
+++ b/tests/lang/test_en.py
@@ -182,3 +182,13 @@ def test_en_currency_audit_includes_common_codes():
     # No NotImplementedError for these codes
     for c in ["NZD", "HKD", "CNY", "KRW", "MXN", "BRL", "ZAR", "SAR", "QAR", "KWD"]:
         num2words(12, lang="en", to="currency", currency=c)
+
+
+def test_en_mixed_text_and_numerals():
+    # Regression for num2words2#61 (ports savoirfairelinux/num2words#281).
+    from num2words2 import num2words
+    assert num2words("text 1", lang="en") == "text one"
+    assert num2words("I have 5 apples", lang="en") == "I have five apples"
+    # Pure numeric strings still work.
+    assert num2words("5", lang="en") == "five"
+    assert num2words("5.5", lang="en") == "five point five"


### PR DESCRIPTION
Closes #61 (ports savoirfairelinux/num2words#281 by @aaronrudkin).

```python
>>> num2words('text 1', lang='en')
'text one'
>>> num2words('I have 5 apples', lang='en')
'I have five apples'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)