### PR TITLE
es: parse ordinal-suffix strings ('1ra', '1ro', '2do', …)

### DIFF
--- a/num2words2/lang_ES.py
+++ b/num2words2/lang_ES.py
@@ -235,6 +235,43 @@ class Num2Word_ES(Num2Word_EUR):
     GIGA_SUFFIX = None
     MEGA_SUFFIX = "illón"
 
+    # Spanish ordinal-suffix tokens that callers send as strings:
+    # '1ro' -> 'primero', '1ra' -> 'primera', etc. Issue #62 ports
+    # savoirfairelinux/num2words#413.
+    _ORDINAL_SUFFIXES = {
+        "ro": ("ordinal", "m"),
+        "do": ("ordinal", "m"),
+        "mo": ("ordinal", "m"),
+        "to": ("ordinal", "m"),
+        "no": ("ordinal", "m"),
+        "vo": ("ordinal", "m"),
+        "ra": ("ordinal", "f"),
+        "da": ("ordinal", "f"),
+        "ma": ("ordinal", "f"),
+        "ta": ("ordinal", "f"),
+        "na": ("ordinal", "f"),
+        "va": ("ordinal", "f"),
+    }
+
+    def str_to_number(self, value):
+        s = str(value).strip()
+        if len(s) >= 3 and s[-2:] in self._ORDINAL_SUFFIXES:
+            digits = s[:-2]
+            if digits.isdigit():
+                # Stash gender hint for to_cardinal to pick up. We bypass
+                # that by directly returning the ordinal form here.
+                _, gender = self._ORDINAL_SUFFIXES[s[-2:]]
+                self._pending_ordinal = (int(digits), gender)
+                return int(digits)
+        return super(Num2Word_ES, self).str_to_number(value)
+
+    def to_cardinal(self, value):
+        pending = getattr(self, "_pending_ordinal", None)
+        if pending is not None and pending[0] == value:
+            self._pending_ordinal = None
+            return self.to_ordinal(value, gender=pending[1])
+        return super(Num2Word_ES, self).to_cardinal(value)
+
     def setup(self):
         lows = ["cuatr", "tr", "b", "m"]
         self.high_numwords = self.gen_high_numwords([], [], lows)

--- a/tests/lang/test_es.py
+++ b/tests/lang/test_es.py
@@ -2782,3 +2782,17 @@ def test_es_uno_intact_when_terminal():
     assert num2words(21, lang="es") == "veintiuno"
     assert num2words(31, lang="es") == "treinta y uno"
     assert num2words(101, lang="es") == "ciento uno"
+
+
+def test_es_ordinal_suffix_parses_to_ordinal_form():
+    # Regression for num2words2#62 (ports savoirfairelinux/num2words#413).
+    from num2words2 import num2words
+    assert num2words("1ro", lang="es") == "primero"
+    assert num2words("1ra", lang="es") == "primera"
+    assert num2words("2do", lang="es") == "segundo"
+    assert num2words("2da", lang="es") == "segunda"
+    assert num2words("3ro", lang="es") == "tercero"
+    assert num2words("3ra", lang="es") == "tercera"
+    # Plain numerics still work
+    assert num2words("1", lang="es") == "uno"
+    assert num2words("5", lang="es") == "cinco"


### PR DESCRIPTION
Closes #62 (ports savoirfairelinux/num2words#413 by @SpyriP).

```python
>>> num2words('1ra', lang='es')
'primera'
>>> num2words('1ro', lang='es')
'primero'
>>> num2words('100ra', lang='es')
'centésima'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)