### PR TITLE
en: reject non-integer floats in to='year'

### DIFF
--- a/num2words2/lang_EN.py
+++ b/num2words2/lang_EN.py
@@ -153,6 +153,14 @@ class Num2Word_EN(lang_EUR.Num2Word_EUR):
         return "%s%s" % (value, self.to_ordinal(value)[-2:])
 
     def to_year(self, val, suffix=None, longval=True):
+        # Years are integers — refuse fractional input rather than emitting
+        # float-precision noise like 'nineteen eighty point five nine nine
+        # nine nine ...'. Issue #67; ports savoirfairelinux/num2words#316.
+        if isinstance(val, float) and not val.is_integer():
+            raise TypeError(
+                "to='year' expects an integer; got non-integer float %r" % val
+            )
+        val = int(val)
         if val < 0:
             val = abs(val)
             suffix = "BC" if not suffix else suffix

--- a/tests/lang/test_en.py
+++ b/tests/lang/test_en.py
@@ -192,3 +192,14 @@ def test_en_mixed_text_and_numerals():
     # Pure numeric strings still work.
     assert num2words("5", lang="en") == "five"
     assert num2words("5.5", lang="en") == "five point five"
+
+
+def test_en_year_rejects_non_integer_float():
+    # Regression for num2words2#67 (ports savoirfairelinux/num2words#316).
+    import pytest
+    from num2words2 import num2words
+    with pytest.raises(TypeError):
+        num2words(1980.6, lang="en", to="year")
+    # Integer floats are accepted (1980.0 == 1980).
+    assert num2words(1980.0, lang="en", to="year") == "nineteen eighty"
+    assert num2words(1980, lang="en", to="year") == "nineteen eighty"


### PR DESCRIPTION
Closes #67 (ports savoirfairelinux/num2words#316 by @nmstoker).

```python
>>> num2words(1980.6, lang='en', to='year')
TypeError: to='year' expects an integer; got non-integer float 1980.6
>>> num2words(1980.0, lang='en', to='year')   # integer floats still OK
'nineteen eighty'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)