### PR TITLE
cs: align string and float decimal output

### DIFF
--- a/num2words2/lang_CS.py
+++ b/num2words2/lang_CS.py
@@ -105,6 +105,13 @@ class Num2Word_CS(Num2Word_Base):
             abs_n = n[1:] if is_negative else n
             left, right = abs_n.split(".")
 
+            # Strip trailing zeros from the fractional part so that the
+            # string '1.50' and the float 1.50 yield the same output
+            # ('jedna čárka pět'). Issue #75 ports
+            # savoirfairelinux/num2words#458. An all-zero fractional becomes
+            # a single '0' so '1.00' still reads as 'jedna čárka nula'.
+            right = right.rstrip("0") or "0"
+
             # Say each decimal digit individually
             decimal_parts = []
             for digit in right:

--- a/tests/lang/test_cs.py
+++ b/tests/lang/test_cs.py
@@ -114,3 +114,11 @@ class Num2WordsCSTest(TestCase):
         self.assertEqual(num2words(-0.4, lang="cs"), "mínus nula čárka čtyři")
         self.assertEqual(num2words(-0.5, lang="cs"), "mínus nula čárka pět")
         self.assertEqual(num2words(-1.4, lang="cs"), "mínus jedna čárka čtyři")
+
+
+def test_cs_string_and_float_decimal_consistency():
+    # Regression for num2words2#75 (ports savoirfairelinux/num2words#458).
+    from num2words2 import num2words
+    assert num2words("1.50", lang="cs") == num2words(1.50, lang="cs") == "jedna čárka pět"
+    assert num2words("1.00", lang="cs") == num2words(1.00, lang="cs") == "jedna čárka nula"
+    assert num2words("1.123", lang="cs") == num2words(1.123, lang="cs")


### PR DESCRIPTION
Closes #75 (ports savoirfairelinux/num2words#458 by @williamT386).

```python
>>> num2words('1.50', lang='cs')   # was 'jedna čárka pět nula'
'jedna čárka pět'
>>> num2words(1.50, lang='cs')     # unchanged
'jedna čárka pět'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)