### PR TITLE
pt+es: extend high_numwords through 10^57

### DIFF
--- a/num2words2/lang_ES.py
+++ b/num2words2/lang_ES.py
@@ -273,7 +273,9 @@ class Num2Word_ES(Num2Word_EUR):
         return super(Num2Word_ES, self).to_cardinal(value)
 
     def setup(self):
-        lows = ["cuatr", "tr", "b", "m"]
+        # Extend through 10^57 (nonillón). Issue #71 ports
+        # savoirfairelinux/num2words#501.
+        lows = ["non", "oct", "sept", "sext", "quint", "cuatr", "tr", "b", "m"]
         self.high_numwords = self.gen_high_numwords([], [], lows)
         self.negword = "menos "
         self.pointword = "punto"

--- a/num2words2/lang_PT.py
+++ b/num2words2/lang_PT.py
@@ -48,7 +48,9 @@ class Num2Word_PT(Num2Word_EUR):
 
     def setup(self):
         super(Num2Word_PT, self).setup()
-        lows = ["quatr", "tr", "b", "m"]
+        # Extend through 10^57 (nonilião). Issue #71 ports
+        # savoirfairelinux/num2words#501.
+        lows = ["non", "oct", "sept", "sext", "quint", "quatr", "tr", "b", "m"]
         self.high_numwords = self.gen_high_numwords([], [], lows)
         self.negword = "menos "
         self.pointword = "vírgula"

--- a/tests/lang/test_es.py
+++ b/tests/lang/test_es.py
@@ -2796,3 +2796,10 @@ def test_es_ordinal_suffix_parses_to_ordinal_form():
     # Plain numerics still work
     assert num2words("1", lang="es") == "uno"
     assert num2words("5", lang="es") == "cinco"
+
+
+def test_es_handles_10_27_and_above():
+    # Regression for num2words2#71 (ports savoirfairelinux/num2words#501).
+    from num2words2 import num2words
+    assert "quintillón" in num2words(10**30, lang="es")
+    assert "nonillón" in num2words(10**54, lang="es")

--- a/tests/lang/test_pt.py
+++ b/tests/lang/test_pt.py
@@ -364,3 +364,10 @@ class Num2WordsPTTest(TestCase):
         self.assertEqual(num2words(-0.04, lang="pt"), "menos zero vírgula zero quatro")
         self.assertEqual(num2words(-1.4, lang="pt"), "menos um vírgula quatro")
         self.assertEqual(num2words(-10.25, lang="pt"), "menos dez vírgula dois cinco")
+
+
+def test_pt_handles_10_27_and_above():
+    # Regression for num2words2#71 (ports savoirfairelinux/num2words#501).
+    from num2words2 import num2words
+    assert "quintilião" in num2words(10**30, lang="pt")
+    assert "nonilião" in num2words(10**54, lang="pt")


### PR DESCRIPTION
Closes #71 (ports savoirfairelinux/num2words#501 by @Maksolo27).

```python
>>> num2words(10**30, lang='pt')
'um quintilião'
>>> num2words(10**54, lang='pt')
'um nonilião'
>>> num2words(10**30, lang='es')
'un quintillón'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)