### PR TITLE
en_IN: extend Indian numbering scale beyond kharab

### DIFF
--- a/num2words2/lang_EN_IN.py
+++ b/num2words2/lang_EN_IN.py
@@ -26,10 +26,16 @@ class Num2Word_EN_IN(Num2Word_EN):
         self.CURRENCY_FORMS["INR"] = (("rupee", "rupees"), ("paisa", "paise"))
 
     def set_high_numwords(self, high):
-        self.cards[10**11] = "kharab"
-        self.cards[10**9] = "arab"
-        self.cards[10**7] = "crore"
-        self.cards[10**5] = "lakh"
+        # Indian numbering scale (Vedic). Issue #72 ports
+        # savoirfairelinux/num2words#414. Each step is 10^2 once past lakh.
+        self.cards[10 ** 19] = "mahashankh"
+        self.cards[10 ** 17] = "shankh"
+        self.cards[10 ** 15] = "padma"
+        self.cards[10 ** 13] = "neel"
+        self.cards[10 ** 11] = "kharab"
+        self.cards[10 ** 9] = "arab"
+        self.cards[10 ** 7] = "crore"
+        self.cards[10 ** 5] = "lakh"
 
     def to_currency(self, val, currency="INR", **kwargs):
         # Indian English defaults to INR (rupees/paise) instead of EUR.

--- a/tests/lang/test_en_in.py
+++ b/tests/lang/test_en_in.py
@@ -119,3 +119,13 @@ def test_en_in_paise_subunit():
     from num2words2 import num2words
     assert "paise" in num2words(1.50, to="currency", lang="en_IN")
     assert "paisa" in num2words(0.01, to="currency", lang="en_IN")
+
+
+def test_en_in_extends_past_kharab():
+    # Regression for num2words2#72 (ports savoirfairelinux/num2words#414).
+    from num2words2 import num2words
+    assert num2words(10 ** 11, lang="en_IN") == "one kharab"
+    assert num2words(10 ** 13, lang="en_IN") == "one neel"
+    assert num2words(10 ** 15, lang="en_IN") == "one padma"
+    assert num2words(10 ** 17, lang="en_IN") == "one shankh"
+    assert num2words(10 ** 19, lang="en_IN") == "one mahashankh"


### PR DESCRIPTION
Closes #72 (ports savoirfairelinux/num2words#414 by @hardeepparmar).

```python
>>> num2words(10**13, lang='en_IN')
'one neel'
>>> num2words(10**17, lang='en_IN')
'one shankh'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)