### PR TITLE
de: feminine 'eine' before feminine currency words

### DIFF
--- a/num2words2/lang_DE.py
+++ b/num2words2/lang_DE.py
@@ -23,6 +23,10 @@ from .lang_EUR import Num2Word_EUR
 
 
 class Num2Word_DE(Num2Word_EUR):
+    # Feminine grammatical-gender currencies need the numeral 'eine' (not
+    # 'ein'/'eins') when the value ends in 1. Issue #69.
+    FEMININE_CURRENCIES = {"DEM", "INR"}
+
     CURRENCY_FORMS = {
         "EUR": (("Euro", "Euro"), ("Cent", "Cent")),
         "GBP": (("Pfund", "Pfund"), ("Penny", "Pence")),
@@ -214,6 +218,16 @@ class Num2Word_DE(Num2Word_EUR):
             minus_str = self.negword if val < 0 else ""
             abs_val = abs(val)
             money_str = self.to_cardinal(abs_val)
+
+            # German feminine-currency rule: when the currency word is
+            # feminine and the number ends in 'mod 100 == 1', the numeral
+            # takes the feminine form 'eine' instead of 'ein'/'eins'.
+            # Issue #69 ports savoirfairelinux/num2words#462.
+            if currency in self.FEMININE_CURRENCIES and abs_val % 100 == 1:
+                if money_str.endswith("eins"):
+                    money_str = money_str[:-4] + "eine"
+                elif money_str.endswith("ein"):
+                    money_str = money_str + "e"
 
             # Proper pluralization for currency
             if abs_val == 1:

--- a/tests/lang/test_de.py
+++ b/tests/lang/test_de.py
@@ -154,3 +154,15 @@ class Num2WordsDETest(TestCase):
         self.assertEqual(num2words(-0.04, lang="de"), "minus null Komma null vier")
         self.assertEqual(num2words(-1.4, lang="de"), "minus eins Komma vier")
         self.assertEqual(num2words(-10.25, lang="de"), "minus zehn Komma zwei fünf")
+
+
+def test_de_dm_eine_mark_for_feminine_unit():
+    # Regression for num2words2#69 (ports savoirfairelinux/num2words#462).
+    from num2words2 import num2words
+    assert num2words(1, lang="de", to="currency", currency="DEM") == "eine Mark"
+    assert num2words(101, lang="de", to="currency", currency="DEM") == "einhunderteine Mark"
+    assert num2words(1001, lang="de", to="currency", currency="DEM") == "eintausendeine Mark"
+    # 21 ends in '...zwanzig' so the 'ein' rule does not apply
+    assert num2words(21, lang="de", to="currency", currency="DEM") == "einundzwanzig Mark"
+    # Plain 1 EUR (masculine/neuter) unchanged
+    assert num2words(1, lang="de", to="currency", currency="EUR") == "eins Euro"


### PR DESCRIPTION
Closes #69 (ports savoirfairelinux/num2words#462 by @rillig).

```python
>>> num2words(1, lang='de', to='currency', currency='DEM')
'eine Mark'
>>> num2words(101, lang='de', to='currency', currency='DEM')
'einhunderteine Mark'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)