### PR TITLE
de: ordinal compounds without spaces

### DIFF
--- a/num2words2/lang_DE.py
+++ b/num2words2/lang_DE.py
@@ -191,6 +191,11 @@ class Num2Word_DE(Num2Word_EUR):
         # Ordinals involving "Million" etc. are written without a space.
         # see https://de.wikipedia.org/wiki/Million#Sprachliches
         res = re.sub(r" ([a-z]+(illion|illiard)ste)$", lambda m: m.group(1), res)
+        # German ordinals are written without spaces, even in compound
+        # forms like 'einemillionerste'. Issue #59 ports
+        # savoirfairelinux/num2words#357.
+        res = re.sub(r"eine (million|milliard|billion|billiard)", r"ein\1", res)
+        res = res.replace(" ", "")
 
         return res
 

--- a/tests/lang/test_de.py
+++ b/tests/lang/test_de.py
@@ -166,3 +166,13 @@ def test_de_dm_eine_mark_for_feminine_unit():
     assert num2words(21, lang="de", to="currency", currency="DEM") == "einundzwanzig Mark"
     # Plain 1 EUR (masculine/neuter) unchanged
     assert num2words(1, lang="de", to="currency", currency="EUR") == "eins Euro"
+
+
+def test_de_ordinal_compound_no_spaces():
+    # Regression for num2words2#59 (ports savoirfairelinux/num2words#357).
+    from num2words2 import num2words
+    assert num2words(1000001, lang="de", to="ordinal") == "einmillionerste"
+    assert num2words(21000001, lang="de", to="ordinal") == "einundzwanzigmillionenerste"
+    # Existing simple cases still pass
+    assert num2words(1000000, lang="de", to="ordinal") == "millionste"
+    assert num2words(1000, lang="de", to="ordinal") == "tausendste"


### PR DESCRIPTION
Closes #59 (ports savoirfairelinux/num2words#357 by @app/).

```python
>>> num2words(1000001, lang='de', to='ordinal')
'einmillionerste'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)