### PR TITLE
nl: drop spaces in to='year' for 2100-9999

### DIFF
--- a/num2words2/lang_NL.py
+++ b/num2words2/lang_NL.py
@@ -236,23 +236,19 @@ class Num2Word_NL(Num2Word_EUR):
         return forms[0]
 
     def to_year(self, val, longval=True):
-        # For years 1100-1999, use the "[number]honderd" form
-        # e.g. 1600 -> "zestienhonderd" not "duizendzeshonderd"
-        if 1100 <= val <= 1999:
+        # Years that fit the "[N]honderd[M]" shape (1100..9999, except the
+        # 2000..2099 'tweeduizend' window where the cardinal form is more
+        # natural). All written without spaces. Issue #60 ports
+        # savoirfairelinux/num2words#519.
+        if 1100 <= val <= 9999 and not 2000 <= val <= 2099:
             hundreds = val // 100
             remainder = val % 100
-
-            # Convert the hundreds part (11-19)
-            result = self.to_cardinal(hundreds) + "honderd"
-
-            # Add remainder if any
+            result = self.to_cardinal(hundreds).replace(" ", "") + "honderd"
             if remainder:
-                remainder_text = self.to_cardinal(remainder)
-                result = result + remainder_text
-
+                result = result + self.to_cardinal(remainder).replace(" ", "")
             return result
 
-        # For other years, use standard logic
+        # 2000-2099 keeps the 'tweeduizend X' form already in use.
         if not (val // 100) % 10:
             return self.to_cardinal(val)
         return self.to_splitnum(val, hightxt="honderd", longval=longval)

--- a/tests/lang/test_nl.py
+++ b/tests/lang/test_nl.py
@@ -416,7 +416,7 @@ class Num2WordsNLTest(TestCase):
         self.assertEqual(
             num2words(2024, lang="nl", to="year"), "tweeduizend vierentwintig"
         )
-        self.assertEqual(num2words(2100, lang="nl", to="year"), "eenentwintig honderd")
+        self.assertEqual(num2words(2100, lang="nl", to="year"), "eenentwintighonderd")
 
     def test_string_input(self):
         """Test string input conversion."""
@@ -458,3 +458,13 @@ class Num2WordsNLTest(TestCase):
         # Test point word if exists
         if hasattr(converter, "pointword"):
             self.assertIsNotNone(converter.pointword)
+
+
+def test_nl_year_no_spaces_for_2100_plus():
+    # Regression for num2words2#60 (ports savoirfairelinux/num2words#519).
+    from num2words2 import num2words
+    assert num2words(2100, lang="nl", to="year") == "eenentwintighonderd"
+    assert num2words(2150, lang="nl", to="year") == "eenentwintighonderdvijftig"
+    assert num2words(2500, lang="nl", to="year") == "vijfentwintighonderd"
+    # 2000-2099 keeps tweeduizend form
+    assert num2words(2024, lang="nl", to="year") == "tweeduizend vierentwintig"


### PR DESCRIPTION
Closes #60 (ports savoirfairelinux/num2words#519 by @jelmers19).

```python
>>> num2words(2150, lang='nl', to='year')
'eenentwintighonderdvijftig'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)