### PR TITLE
pt_BR: respect '.' vs ',' notation in string input

### DIFF
--- a/num2words2/lang_PT_BR.py
+++ b/num2words2/lang_PT_BR.py
@@ -39,6 +39,31 @@ class Num2Word_PT_BR(lang_PT.Num2Word_PT):
         super(Num2Word_PT_BR, self).__init__()
         self.negword = "menos "
 
+    def str_to_number(self, value):
+        # Brazilian Portuguese uses ',' as the decimal separator. A string
+        # written with '.' (e.g. '1.50') comes from US-style notation and
+        # should be pronounced 'ponto' (point) instead of 'vírgula' (comma).
+        # A string with ',' is the canonical pt-BR form and uses 'vírgula'.
+        # Issue #63 ports savoirfairelinux/num2words#300.
+        s = str(value).strip()
+        if isinstance(value, str) and "." in s and "," not in s:
+            self._pending_pointword = "ponto"
+        else:
+            self._pending_pointword = None
+        return super(Num2Word_PT_BR, self).str_to_number(value)
+
+    def to_cardinal_float(self, value):
+        pending = getattr(self, "_pending_pointword", None)
+        if pending:
+            saved = self.pointword
+            self.pointword = pending
+            try:
+                return super(Num2Word_PT_BR, self).to_cardinal_float(value)
+            finally:
+                self.pointword = saved
+                self._pending_pointword = None
+        return super(Num2Word_PT_BR, self).to_cardinal_float(value)
+
     def setup(self):
         # First call parent setup
         super(Num2Word_PT_BR, self).setup()

--- a/tests/lang/test_pt_BR.py
+++ b/tests/lang/test_pt_BR.py
@@ -683,3 +683,12 @@ class Num2WordsPT_BRTest(TestCase):
             num2words(1001234, lang="pt-br"),
             "um milhão, mil, duzentos e trinta e quatro",
         )
+
+
+def test_pt_br_dot_string_pronounced_as_ponto():
+    # Regression for num2words2#63 (ports savoirfairelinux/num2words#300).
+    from num2words2 import num2words
+    # Dot-string is US notation; pronounce as 'ponto'.
+    assert num2words("1.50", lang="pt_BR") == "um ponto cinco"
+    # Comma-string and float are canonical pt-BR; pronounce as 'vírgula'.
+    assert "vírgula" in num2words(1.50, lang="pt_BR")


### PR DESCRIPTION
Closes #63 (ports savoirfairelinux/num2words#300 by @hypernote).

```python
>>> num2words('1.50', lang='pt_BR')
'um ponto cinco'
>>> num2words(1.50, lang='pt_BR')
'um vírgula cinco'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)