### PR TITLE
ar: use Arabic comma '،' (U+060C) and drop double space in decimals

### DIFF
--- a/num2words2/lang_AR.py
+++ b/num2words2/lang_AR.py
@@ -463,6 +463,10 @@ class Num2Word_AR(Num2Word_Base):
             elif 11 <= remaining100 <= 99:
                 formatted_number += self.currency_unit[3]
         if self._decimalValue != 0:
+            # Trim any trailing whitespace before injecting the separator,
+            # otherwise we get double spaces in the join. Issue #53 ports
+            # savoirfairelinux/num2words#265.
+            formatted_number = formatted_number.rstrip()
             if self.separator == "و":
                 formatted_number += " و"
             else:
@@ -551,7 +555,9 @@ class Num2Word_AR(Num2Word_Base):
         minus = ""
         if number < 0:
             minus = "سالب "
-        self.separator = ","
+        # Arabic uses an Arabic comma U+060C, not a Latin one. Issue #53
+        # ports savoirfairelinux/num2words#265.
+        self.separator = "،"
         self.currency_subunit = ("", "", "", "")
         self.currency_unit = ("", "", "", "")
         self.arabicPrefixText = ""

--- a/tests/lang/test_ar.py
+++ b/tests/lang/test_ar.py
@@ -93,15 +93,15 @@ class TestAR(LangTest, TestCase):
 
     float_tests = [
         # From test_cardinal
-        (12.3, "اثنا عشر  , ثلاثون"),
-        (12.01, "اثنا عشر  , إحدى"),
-        (12.02, "اثنا عشر  , اثنتان"),
-        (12.03, "اثنا عشر  , ثلاث"),
-        (12.34, "اثنا عشر  , أربع وثلاثون"),
+        (12.3, "اثنا عشر ، ثلاثون"),
+        (12.01, "اثنا عشر ، إحدى"),
+        (12.02, "اثنا عشر ، اثنتان"),
+        (12.03, "اثنا عشر ، ثلاث"),
+        (12.34, "اثنا عشر ، أربع وثلاثون"),
         # From test_negative_decimals
-        (-0.4, "سالب , أربعون"),
-        (-0.5, "سالب , خمسون"),
-        (-1.4, "سالب واحد  , أربعون"),
+        (-0.4, "سالب ، أربعون"),
+        (-0.5, "سالب ، خمسون"),
+        (-1.4, "سالب واحد ، أربعون"),
     ]
 
     negative_tests = [
@@ -149,3 +149,12 @@ class TestAR(LangTest, TestCase):
             with self.assertRaises(OverflowError) as context:
                 num2words(number, lang="ar")
             self.assertTrue("must be less" in str(context.exception))
+
+
+def test_ar_decimal_uses_arabic_comma_no_double_space():
+    # Regression for num2words2#53 (ports savoirfairelinux/num2words#265).
+    from num2words2 import num2words
+    out = num2words(667851.14, lang="ar")
+    assert "،" in out  # Arabic comma U+060C
+    assert "," not in out  # no Latin comma
+    assert "  " not in out  # no double space


### PR DESCRIPTION
Closes #53 (ports savoirfairelinux/num2words#265 by @ahmad18189).

```python
>>> num2words(667851.14, lang='ar')
'ستمائة وسبعة وستون ألفاً وثمانمائة وواحد وخمسون ، أربع عشرة'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)