### PR TITLE
tr: emit 'bir' between yüz/bin in 6-digit numbers (401607 etc.)

### DIFF
--- a/num2words2/lang_TR.py
+++ b/num2words2/lang_TR.py
@@ -254,14 +254,14 @@ class Num2Word_TR(Num2Word_Base):
                     return "%s%s" % (pre_word, wrd)
                 if self.order_of_last_zero_digit < len(self.integers_to_read[0]) - 3:
                     # number like xyz and all others, read cardinal xyz n..n
+                    # Issue #64: the previous code dropped 'bir' for 6-digit
+                    # numbers ending in 1 (e.g. 401607), producing
+                    # 'dörtyüzbinaltıyüzyedi' instead of
+                    # 'dörtyüzbirbinaltıyüzyedi'.
                     wrd += self.HUNDREDS.get(self.integers_to_read[0][0], "")
                     wrd += self.CARDINAL_HUNDRED[0]
                     wrd += self.CARDINAL_TENS.get(self.integers_to_read[0][1], "")
-                    if not (
-                        self.total_triplets_to_read == 2
-                        and self.integers_to_read[0][2] == "1"
-                    ):
-                        wrd += self.CARDINAL_ONES.get(self.integers_to_read[0][2], "")
+                    wrd += self.CARDINAL_ONES.get(self.integers_to_read[0][2], "")
                     wrd += self.CARDINAL_TRIPLETS[self.total_triplets_to_read - 1]
 
             for i in list(range(self.total_triplets_to_read - 1, 0, -1)):

--- a/tests/lang/test_tr.py
+++ b/tests/lang/test_tr.py
@@ -403,3 +403,13 @@ class Num2WordsTRTest(TestCase):
         # Test point word if exists
         if hasattr(converter, "pointword"):
             self.assertIsNotNone(converter.pointword)
+
+
+def test_tr_bir_inserted_between_hundred_and_thousand_in_6_digit_numbers():
+    # Regression for num2words2#64 (ports savoirfairelinux/num2words#621/#564).
+    from num2words2 import num2words
+    assert num2words(401607, lang="tr") == "dörtyüzbirbinaltıyüzyedi"
+    assert num2words(301661, lang="tr") == "üçyüzbirbinaltıyüzaltmışbir"
+    assert num2words(201605, lang="tr") == "ikiyüzbirbinaltıyüzbeş"
+    # 1×1000 still suppresses 'bir' (canonical Turkish)
+    assert num2words(1100, lang="tr") == "binyüz"


### PR DESCRIPTION
Partial-closes #64 (the 'missing bir' part).

```python
>>> num2words(401607, lang='tr')
'dörtyüzbirbinaltıyüzyedi'   # was 'dörtyüzbinaltıyüzyedi'
>>> num2words(1100, lang='tr')
'binyüz'                     # 1×1000 still suppresses 'bir' as expected
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)