### PR TITLE
ci(aur): render .SRCINFO with sed; bump in-repo template to v1.0.4

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -54,11 +54,13 @@ jobs:
               -e "s/^sha256sums=.*/sha256sums=('${sha}')/" \
               packaging/aur/python-num2words2/PKGBUILD > out/PKGBUILD
 
-          # Re-render .SRCINFO from the new PKGBUILD using makepkg in an Arch container.
-          docker run --rm -v "$PWD/out:/pkg" archlinux:base-devel bash -c '
-            cd /pkg && \
-            sudo -u nobody makepkg --printsrcinfo > .SRCINFO
-          '
+          # Re-render .SRCINFO via sed on the existing template instead of
+          # makepkg in a container. Avoids the docker permission failure on
+          # hosted runners and keeps the transform deterministic.
+          sed -e "s/^\tpkgver = .*/\tpkgver = ${version}/" \
+              -e "s|^\tsource = .*|\tsource = https://files.pythonhosted.org/packages/source/n/num2words2/num2words2-${version}.tar.gz|" \
+              -e "s/^\tsha256sums = .*/\tsha256sums = ${sha}/" \
+              packaging/aur/python-num2words2/.SRCINFO > out/.SRCINFO
 
       - name: Push to AUR
         uses: KSXGitHub/github-actions-deploy-aur@v2.7.2

--- a/packaging/aur/python-num2words2/.SRCINFO
+++ b/packaging/aur/python-num2words2/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = python-num2words2
 	pkgdesc = Modules to convert numbers to words. Actively-maintained fork of num2words with 159+ language codes.
-	pkgver = 1.0.3
+	pkgver = 1.0.4
 	pkgrel = 1
 	url = https://github.com/jqueguiner/num2words2
 	arch = any
@@ -13,7 +13,7 @@ pkgbase = python-num2words2
 	makedepends = python-wheel
 	depends = python
 	depends = python-docopt
-	source = https://files.pythonhosted.org/packages/source/n/num2words2/num2words2-1.0.3.tar.gz
-	sha256sums = 32388edf7e783f64f3476c6ff259e950a9d1709ff57d6100cd43099f6d09675f
+	source = https://files.pythonhosted.org/packages/source/n/num2words2/num2words2-1.0.4.tar.gz
+	sha256sums = a87e45b6b7ee557e14a7c3ea12a0017ec2e76c17ee812d3db35860ada4b56dc2
 
 pkgname = python-num2words2

--- a/packaging/aur/python-num2words2/PKGBUILD
+++ b/packaging/aur/python-num2words2/PKGBUILD
@@ -1,7 +1,7 @@
-# Maintainer: Jean-Louis Queguiner <jean-louis.queguiner@gmail.com>
+# Maintainer: Jean-Louis Queguiner <jlqueguiner@gladia.io>
 pkgname=python-num2words2
 _pkgname=num2words2
-pkgver=1.0.3
+pkgver=1.0.4
 pkgrel=1
 pkgdesc="Modules to convert numbers to words. Actively-maintained fork of num2words with 159+ language codes."
 arch=('any')
@@ -15,7 +15,7 @@ makedepends=('python-build'
              'python-wheel')
 checkdepends=('python-pytest')
 source=("https://files.pythonhosted.org/packages/source/n/${_pkgname}/${_pkgname}-${pkgver}.tar.gz")
-sha256sums=('32388edf7e783f64f3476c6ff259e950a9d1709ff57d6100cd43099f6d09675f')
+sha256sums=('a87e45b6b7ee557e14a7c3ea12a0017ec2e76c17ee812d3db35860ada4b56dc2')
 
 build() {
   cd "${_pkgname}-${pkgver}"


### PR DESCRIPTION
Fixes the v1.0.4 AUR auto-publish failure.

The workflow used `docker run archlinux:base-devel sudo -u nobody makepkg --printsrcinfo` to regenerate .SRCINFO, but on hosted runners the `nobody` user can't write to the bind-mounted directory:
> ==> ERROR: You do not have write permission for the directory $BUILDDIR (/pkg).

Replaced with a deterministic sed transform on the existing .SRCINFO template — same result, no docker.

Also bumps the in-repo `PKGBUILD` / `.SRCINFO` to v1.0.4 (the manual AUR push already shipped this content) and switches the maintainer email to `jlqueguiner@gladia.io`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)