### PR TITLE
fr/fr_BE/fr_CH: linguistic corrections per upstream #532

### DIFF
--- a/num2words2/lang_FR.py
+++ b/num2words2/lang_FR.py
@@ -38,6 +38,11 @@ class Num2Word_FR(Num2Word_EUR):
         "MXN": (("peso", "pesos"), ("centavo", "centavos")),
     }
 
+    def pluralize(self, n, forms):
+        # French: 0 and 1 take the singular form. Issue #70 ports
+        # savoirfairelinux/num2words#532 ('zéro centime', not 'zéro centimes').
+        return forms[0] if abs(n) <= 1 else forms[1]
+
     def setup(self):
         Num2Word_EUR.setup(self)
 
@@ -112,11 +117,34 @@ class Num2Word_FR(Num2Word_EUR):
     # Is this right for such things as 1001 - "mille unième" instead of
     # "mille premier"??  "millième"??
 
+    _BIG_UNITS = (
+        "trilliard",
+        "trillion",
+        "billiard",
+        "billion",
+        "milliard",
+        "million",
+    )
+
     def to_ordinal(self, value):
         self.verify_ordinal(value)
         if value == 1:
             return "premier"
         word = self.to_cardinal(value)
+        # Big-unit ordinals (million / milliard / billion / trillion …) need
+        # special handling: drop a leading 'un ' (singular form is just
+        # 'millionième', not 'un millionième'), strip any trailing plural
+        # 's', and re-pluralize the -ième suffix when the count is > 1.
+        # Issue #70 ports savoirfairelinux/num2words#532.
+        for unit in self._BIG_UNITS:
+            if word == "un " + unit or word.endswith(" " + unit + "s"):
+                plural = word.endswith("s")
+                stripped = word.rstrip("s")
+                if stripped.startswith("un "):
+                    stripped = stripped[len("un ") :]
+                return stripped + "ième" + ("s" if plural else "")
+            if word == unit:
+                return unit + "ième"
         for src, repl in self.ords.items():
             if word.endswith(src):
                 word = word[: -len(src)] + repl

--- a/num2words2/lang_FR_BE.py
+++ b/num2words2/lang_FR_BE.py
@@ -42,9 +42,23 @@ class Num2Word_FR_BE(Num2Word_FR):
         if cnum == 1:
             if nnum < 1000000:
                 return next
-
-        if cnum < 1000 and nnum != 1000 and ntext[-1] != "s" and not nnum % 100:
-            ntext += "s"
+        else:
+            # Drop trailing 's' from 'cents' / 'vingts' when followed by
+            # another word: 'sept cent vingt-neuf' (not 'sept cents vingt-
+            # neuf'). Issue #70 ports savoirfairelinux/num2words#532.
+            if (
+                (not (cnum - 80) % 100 or (not cnum % 100 and cnum < 1000))
+                and nnum < 1000000
+                and ctext[-1] == "s"
+            ):
+                ctext = ctext[:-1]
+            if (
+                cnum < 1000
+                and nnum != 1000
+                and ntext[-1] != "s"
+                and not nnum % 100
+            ):
+                ntext += "s"
 
         if nnum < cnum < 100:
             if nnum % 10 == 1:

--- a/num2words2/lang_FR_CH.py
+++ b/num2words2/lang_FR_CH.py
@@ -41,9 +41,23 @@ class Num2Word_FR_CH(Num2Word_FR):
         if cnum == 1:
             if nnum < 1000000:
                 return next
-
-        if cnum < 1000 and nnum != 1000 and ntext[-1] != "s" and not nnum % 100:
-            ntext += "s"
+        else:
+            # Drop trailing 's' from 'cents' / 'vingts' before continuation
+            # and only pluralize when not a unit-1 multiplier. Same fix as
+            # fr_BE; see issue #70.
+            if (
+                (not (cnum - 80) % 100 or (not cnum % 100 and cnum < 1000))
+                and nnum < 1000000
+                and ctext[-1] == "s"
+            ):
+                ctext = ctext[:-1]
+            if (
+                cnum < 1000
+                and nnum != 1000
+                and ntext[-1] != "s"
+                and not nnum % 100
+            ):
+                ntext += "s"
 
         if nnum < cnum < 100:
             if nnum % 10 == 1:

--- a/tests/lang/test_fr.py
+++ b/tests/lang/test_fr.py
@@ -99,9 +99,9 @@ TEST_CASES_ORDINAL = (
     (28, "vingt-huitième"),
     (100, "centième"),
     (1000, "millième"),
-    (1000000, "un millionième"),
-    (1000000000000000, "un billiardième"),
-    (1000000000000000000, "un trillionième"),  # over 1e18 is not supported
+    (1000000, "millionième"),
+    (1000000000000000, "billiardième"),
+    (1000000000000000000, "trillionième"),  # over 1e18 is not supported
 )
 
 TEST_CASES_ORDINAL_NUM = (

--- a/tests/lang/test_fr_be.py
+++ b/tests/lang/test_fr_be.py
@@ -25,19 +25,19 @@ TEST_CASES_CARDINAL = (
     (79, "septante-neuf"),
     (89, "quatre-vingt-neuf"),
     (95, "nonante-cinq"),
-    (729, "sept cents vingt-neuf"),
-    (894, "huit cents nonante-quatre"),
-    (999, "neuf cents nonante-neuf"),
-    (7232, "sept mille deux cents trente-deux"),
-    (8569, "huit mille cinq cents soixante-neuf"),
-    (9539, "neuf mille cinq cents trente-neuf"),
-    (1000000, "un millions"),
-    (1000001, "un millions un"),
+    (729, "sept cent vingt-neuf"),
+    (894, "huit cent nonante-quatre"),
+    (999, "neuf cent nonante-neuf"),
+    (7232, "sept mille deux cent trente-deux"),
+    (8569, "huit mille cinq cent soixante-neuf"),
+    (9539, "neuf mille cinq cent trente-neuf"),
+    (1000000, "un million"),
+    (1000001, "un million un"),
     (4000000, "quatre millions"),
     (10000000000000, "dix billions"),
     (100000000000000, "cent billions"),
-    (1000000000000000000, "un trillions"),
-    (1000000000000000000000, "un trilliards"),
+    (1000000000000000000, "un trillion"),
+    (1000000000000000000000, "un trilliard"),
     (10000000000000000000000000, "dix quadrillions"),
 )
 
@@ -49,9 +49,9 @@ TEST_CASES_ORDINAL = (
     (28, "vingt-huitième"),
     (100, "centième"),
     (1000, "millième"),
-    (1000000, "un millionsième"),
-    (1000000000000000, "un billiardsième"),
-    (1000000000000000000, "un trillionsième"),  # over 1e18 is not supported
+    (1000000, "millionième"),
+    (1000000000000000, "billiardième"),
+    (1000000000000000000, "trillionième"),  # over 1e18 is not supported
 )
 
 TEST_CASES_TO_CURRENCY_EUR = (
@@ -88,7 +88,7 @@ class Num2WordsENTest(TestCase):
         self.assertEqual(num2words(71, lang=LANG), "septante et un")
         self.assertEqual(num2words(81, lang=LANG), "quatre-vingt et un")
         self.assertEqual(num2words(80, lang=LANG), "quatre-vingt")
-        self.assertEqual(num2words(880, lang=LANG), "huit cents quatre-vingt")
+        self.assertEqual(num2words(880, lang=LANG), "huit cent quatre-vingt")
         self.assertEqual(num2words(91, ordinal=True, lang=LANG), "nonante et unième")
         self.assertEqual(num2words(53, lang=LANG), "cinquante-trois")
 
@@ -115,3 +115,28 @@ class Num2WordsENTest(TestCase):
         self.assertEqual(num2words(-0.4, lang="fr_BE"), "moins zéro virgule quatre")
         self.assertEqual(num2words(-0.5, lang="fr_BE"), "moins zéro virgule cinq")
         self.assertEqual(num2words(-1.4, lang="fr_BE"), "moins un virgule quatre")
+
+
+def test_fr_be_corrections_from_upstream_532():
+    # Regression for num2words2#70 (ports savoirfairelinux/num2words#532).
+    from num2words2 import num2words
+
+    # Cardinal: cents singular before continuation, million/trillion/trilliard
+    # singular when count is 1.
+    assert num2words(729, lang="fr_BE") == "sept cent vingt-neuf"
+    assert num2words(894, lang="fr_BE") == "huit cent nonante-quatre"
+    assert num2words(1_000_000, lang="fr_BE") == "un million"
+    assert num2words(1_000_001, lang="fr_BE") == "un million un"
+    assert num2words(10 ** 18, lang="fr_BE") == "un trillion"
+    assert num2words(10 ** 21, lang="fr_BE") == "un trilliard"
+
+    # Ordinal: drop leading 'un', drop trailing 's' before -ième, and
+    # pluralize -ième when count > 1.
+    assert num2words(1_000_000, lang="fr_BE", to="ordinal") == "millionième"
+    assert num2words(2_000_000, lang="fr_BE", to="ordinal") == "deux millionièmes"
+    assert num2words(10 ** 15, lang="fr_BE", to="ordinal") == "billiardième"
+
+    # Currency: zéro takes singular for both major and minor unit.
+    assert num2words(1.00, lang="fr_BE", to="currency") == "un euro et zéro centime"
+    assert num2words(100.00, lang="fr_BE", to="currency") == "cent euros et zéro centime"
+    assert num2words(1.00, lang="fr_BE", to="currency", currency="FRF") == "un franc et zéro centime"

--- a/tests/lang/test_fr_ch.py
+++ b/tests/lang/test_fr_ch.py
@@ -26,19 +26,19 @@ TEST_CASES_CARDINAL = (
     (79, "septante-neuf"),
     (89, "huitante-neuf"),
     (95, "nonante-cinq"),
-    (729, "sept cents vingt-neuf"),
-    (894, "huit cents nonante-quatre"),
-    (999, "neuf cents nonante-neuf"),
-    (7232, "sept mille deux cents trente-deux"),
-    (8569, "huit mille cinq cents soixante-neuf"),
-    (9539, "neuf mille cinq cents trente-neuf"),
-    (1000000, "un millions"),
-    (1000001, "un millions un"),
+    (729, "sept cent vingt-neuf"),
+    (894, "huit cent nonante-quatre"),
+    (999, "neuf cent nonante-neuf"),
+    (7232, "sept mille deux cent trente-deux"),
+    (8569, "huit mille cinq cent soixante-neuf"),
+    (9539, "neuf mille cinq cent trente-neuf"),
+    (1000000, "un million"),
+    (1000001, "un million un"),
     (4000000, "quatre millions"),
     (10000000000000, "dix billions"),
     (100000000000000, "cent billions"),
-    (1000000000000000000, "un trillions"),
-    (1000000000000000000000, "un trilliards"),
+    (1000000000000000000, "un trillion"),
+    (1000000000000000000000, "un trilliard"),
     (10000000000000000000000000, "dix quadrillions"),
 )
 
@@ -50,9 +50,9 @@ TEST_CASES_ORDINAL = (
     (28, "vingt-huitième"),
     (100, "centième"),
     (1000, "millième"),
-    (1000000, "un millionsième"),
-    (1000000000000000, "un billiardsième"),
-    (1000000000000000000, "un trillionsième"),  # over 1e18 is not supported
+    (1000000, "millionième"),
+    (1000000000000000, "billiardième"),
+    (1000000000000000000, "trillionième"),  # over 1e18 is not supported
 )
 
 TEST_CASES_TO_CURRENCY_EUR = (
@@ -86,7 +86,7 @@ class Num2WordsENTest(TestCase):
         self.assertEqual(num2words(71, lang="fr_CH"), "septante et un")
         self.assertEqual(num2words(81, lang="fr_CH"), "huitante et un")
         self.assertEqual(num2words(80, lang="fr_CH"), "huitante")
-        self.assertEqual(num2words(880, lang="fr_CH"), "huit cents huitante")
+        self.assertEqual(num2words(880, lang="fr_CH"), "huit cent huitante")
         self.assertEqual(num2words(91, ordinal=True, lang="fr_CH"), "nonante et unième")
         self.assertEqual(num2words(53, lang="fr_CH"), "cinquante-trois")
 


### PR DESCRIPTION
Closes #70 (ports savoirfairelinux/num2words#532 by @Vincent-Stragier).

Three classes of fix:

1. **Cardinal**: 'cents'/'vingts' singular before continuation, 'un million'/'un milliard' singular when count is 1.
2. **Ordinal**: drop leading 'un', drop trailing 's' before -ième, plural -ième when count > 1.
3. **Currency**: 'zéro' is grammatically singular ('zéro centime', not 'zéro centimes').

Fix applies to fr (parent), fr_BE, fr_CH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)