### PR TITLE
ar: add case= kwarg switching dual ending ان ↔ ين

### DIFF
--- a/num2words2/lang_AR.py
+++ b/num2words2/lang_AR.py
@@ -629,7 +629,37 @@ class Num2Word_AR(Num2Word_Base):
     def to_ordinal_num(self, value):
         return self.to_ordinal(value).strip()
 
-    def to_cardinal(self, number):
+    # Aliases accepted by the case= kwarg. Issue #55 ports
+    # savoirfairelinux/num2words#557.
+    _AR_NOMINATIVE = {"n", "nominative", "رفع", "مرفوع"}
+    _AR_OBLIQUE = {  # accusative + genitive both use the ين dual ending
+        "a", "accusative", "نصب", "منصوب",
+        "g", "genitive", "جر", "مجرور",
+        "o", "oblique",
+    }
+    # Dual-noun endings that switch between nominative (ان) and oblique (ين).
+    # Order matters: longer-stem matches must come first so we don't
+    # accidentally rewrite a substring of a larger word.
+    _AR_DUAL_NOMINATIVE_TO_OBLIQUE = [
+        ("كوادريليونان", "كوادريليونين"),
+        ("تريليونان", "تريليونين"),
+        ("مليونان", "مليونين"),
+        ("ملياران", "مليارين"),
+        ("ألفان", "ألفين"),
+        ("مئتان", "مئتين"),
+    ]
+    # When the entire output IS the construct form (no following counted
+    # noun), normalize to the independent form for the requested case.
+    _AR_STANDALONE_DUAL = {
+        "مئتا": ("مئتان", "مئتين"),
+        "ألفا": ("ألفان", "ألفين"),
+        "مليونا": ("مليونان", "مليونين"),
+        "مليارا": ("ملياران", "مليارين"),
+        "تريليونا": ("تريليونان", "تريليونين"),
+        "كوادريليونا": ("كوادريليونان", "كوادريليونين"),
+    }
+
+    def to_cardinal(self, number, case="nominative"):
         self.isCurrencyNameFeminine = False
         number = self.validate_number(number)
         minus = ""
@@ -644,7 +674,21 @@ class Num2Word_AR(Num2Word_Base):
         self.arabicSuffixText = ""
         self.arabicOnes = ARABIC_ONES
         self.partPrecision = 2
-        return minus + self.convert(value=self.abs(number)).strip()
+        out = minus + self.convert(value=self.abs(number)).strip()
+        # Decide which dual ending to apply.
+        is_oblique = isinstance(case, str) and case.lower() in self._AR_OBLIQUE
+        # Standalone (construct) form: number is exactly مئتا / ألفا / مليونا /
+        # مليارا / تريليونا / كوادريليونا — switch to the independent form.
+        bare = out.lstrip(minus).strip()
+        if bare in self._AR_STANDALONE_DUAL:
+            nom, obl = self._AR_STANDALONE_DUAL[bare]
+            out = (minus + (obl if is_oblique else nom)).strip()
+            return out
+        # Compound forms (e.g. 205 → مئتان وخمسة): switch ان → ين if oblique.
+        if is_oblique:
+            for nom, obl in self._AR_DUAL_NOMINATIVE_TO_OBLIQUE:
+                out = out.replace(nom, obl)
+        return out
 
     def to_currency(self, n, currency="SR", cents=True, separator=",", adjective=False):
         # Arabic has a special currency implementation

--- a/tests/lang/test_ar.py
+++ b/tests/lang/test_ar.py
@@ -63,7 +63,9 @@ class TestAR(LangTest, TestCase):
     cardinal_tests = [
         (0, "صفر"),
         # These are actually from test_cardinal, but are integers
-        (200, "مئتا"),
+        # 200/2000 alone are now the independent dual form (مئتان / ألفان);
+        # the construct form is only correct when followed by a noun.
+        (200, "مئتان"),
         (700, "سبعمائة"),
         (101010, "مائة وألف ألف وعشرة"),
         (431, "أربعمائة وواحد وثلاثون"),
@@ -115,7 +117,7 @@ class TestAR(LangTest, TestCase):
     ]
 
     year_tests = [
-        (2000, "ألفا"),
+        (2000, "ألفان"),
     ]
 
     def test_cardinal(self):
@@ -197,3 +199,26 @@ def test_ar_ordinals_feminine():
     assert ar.to_ordinal(1, gender="f") == "الأولى"
     assert ar.to_ordinal(2, gender="f") == "الثانية"
     assert ar.to_ordinal(11, gender="f") == "الحادية عشرة"
+
+
+def test_ar_dual_endings_switch_with_case_kwarg():
+    # Regression for num2words2#55 (ports savoirfairelinux/num2words#557).
+    from num2words2 import num2words
+
+    # Standalone dual nouns: independent form, not construct.
+    assert num2words(200, lang="ar") == "مئتان"
+    assert num2words(2000, lang="ar") == "ألفان"
+    assert num2words(2_000_000, lang="ar") == "مليونان"
+
+    # Accusative / genitive use the ين ending.
+    assert num2words(200, lang="ar", case="accusative") == "مئتين"
+    assert num2words(2000, lang="ar", case="accusative") == "ألفين"
+    assert num2words(2_000_000, lang="ar", case="genitive") == "مليونين"
+    assert num2words(200, lang="ar", case="a") == "مئتين"
+    assert num2words(200, lang="ar", case="نصب") == "مئتين"
+    assert num2words(200, lang="ar", case="جر") == "مئتين"
+
+    # Compound forms also switch.
+    assert num2words(205, lang="ar") == "مئتان وخمسة"
+    assert num2words(205, lang="ar", case="accusative") == "مئتين وخمسة"
+    assert num2words(2005, lang="ar", case="accusative") == "ألفين وخمسة"


### PR DESCRIPTION
Closes #55 (ports savoirfairelinux/num2words#557 by @bm-rana).

```python
>>> num2words(200, lang='ar')
'مئتان'                # nominative dual (was 'مئتا' construct form)
>>> num2words(200, lang='ar', case='accusative')
'مئتين'
>>> num2words(205, lang='ar', case='accusative')
'مئتين وخمسة'
```

Accepted aliases: `'nominative'/'n'` (default), `'accusative'/'a'`, `'genitive'/'g'`, `'oblique'/'o'`, plus the Arabic terms `'رفع'/'نصب'/'جر'` and `'مرفوع'/'منصوب'/'مجرور'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)