### PR TITLE
tr: add spaced/precision/decimal_word kwargs to to_cardinal

### DIFF
--- a/num2words2/lang_TR.py
+++ b/num2words2/lang_TR.py
@@ -124,7 +124,27 @@ class Num2Word_TR(Num2Word_Base):
         self.total_digits_outside_triplets = 0
         self.order_of_last_zero_digit = 0
 
-    def to_cardinal(self, value):
+    def to_cardinal(self, value, spaced=False, precision=None, decimal_word=None):
+        # Apply caller-provided overrides for the duration of this call.
+        # Issue #64 part 2/3 ports savoirfairelinux/num2words#486 + #534.
+        saved_precision = self.precision
+        saved_pointword = self.pointword
+        if precision is not None:
+            self.precision = int(precision)
+        if decimal_word is not None:
+            self.pointword = decimal_word
+        try:
+            wrd = self._to_cardinal_impl(value)
+            # Tokenize while pointword is still the caller's chosen word so
+            # the custom decimal_word is recognized as its own token.
+            if spaced:
+                wrd = self._insert_spaces(wrd)
+        finally:
+            self.precision = saved_precision
+            self.pointword = saved_pointword
+        return wrd
+
+    def _to_cardinal_impl(self, value):
         wrd = ""
         is_cardinal = self.verify_cardinal(value)
         if not is_cardinal:
@@ -420,28 +440,80 @@ class Num2Word_TR(Num2Word_Base):
         is_negative = value < 0
         abs_value = abs(value)
 
-        self.to_splitnum(abs_value)
-        wrd = ""
-        wrd += self.pointword
-        fractional = self.integers_to_read[1]
-        if len(fractional) == 2 and fractional[0] == "0" and fractional[1] != "0":
-            # Without this, 0.03 would drop its leading zero and read as 0.3.
-            wrd += self.ZERO
-            wrd += self.CARDINAL_ONES.get(fractional[1], "")
+        # Use string formatting that respects self.precision so we can emit
+        # arbitrary fractional digits (issue #64 part 3 / upstream #534).
+        prec = max(int(self.precision), 1)
+        whole_str = "{:.{p}f}".format(abs_value, p=prec)
+        if "." in whole_str:
+            int_part, frac_part = whole_str.split(".")
         else:
-            if len(fractional) >= 1:
-                wrd += self.CARDINAL_TENS.get(fractional[0], "")
-            if len(fractional) == 2:
-                wrd += self.CARDINAL_ONES.get(fractional[1], "")
+            int_part, frac_part = whole_str, "0" * prec
 
-        if self.integers_to_read[0] == "0":
+        wrd = self.pointword
+        # If exactly 2 digits (the historical default precision), preserve
+        # the existing tens-and-ones reading so old callers keep working.
+        if prec == 2:
+            if frac_part[0] == "0" and frac_part[1] != "0":
+                wrd += self.ZERO
+                wrd += self.CARDINAL_ONES.get(frac_part[1], "")
+            else:
+                wrd += self.CARDINAL_TENS.get(frac_part[0], "")
+                wrd += self.CARDINAL_ONES.get(frac_part[1], "")
+        else:
+            # Higher precision: read the fractional part as a single integer
+            # (with leading-zero ZEROs spelled out separately, matching how
+            # 0.03 reads at precision=2).
+            leading_zeros = len(frac_part) - len(frac_part.lstrip("0"))
+            for _ in range(leading_zeros):
+                wrd += self.ZERO
+            stripped = frac_part.lstrip("0")
+            if stripped:
+                wrd += self._to_cardinal_impl(int(stripped))
+
+        if int_part == "0":
             wrd = self.ZERO + wrd
         else:
-            wrd = self.to_cardinal(int(self.integers_to_read[0])) + wrd
+            wrd = self._to_cardinal_impl(int(int_part)) + wrd
 
         if is_negative:
             wrd = self.negword + " " + wrd
         return wrd
+
+    def _insert_spaces(self, text):
+        # Greedy longest-first tokenizer: walk the text and emit each known
+        # Turkish token separated by a single space. Issue #64 part 2 ports
+        # savoirfairelinux/num2words#486.
+        tokens = []
+        tokens.extend(self.CARDINAL_TRIPLETS.values())
+        tokens.extend(self.CARDINAL_HUNDRED)
+        tokens.extend(self.CARDINAL_TENS.values())
+        tokens.extend(self.CARDINAL_ONES.values())
+        tokens.append(self.ZERO)
+        tokens.append(self.pointword)
+        # Sort longest first so 'doksandokuz' beats 'doksan' + 'dokuz'.
+        tokens = sorted({t for t in tokens if t}, key=len, reverse=True)
+        out = []
+        i = 0
+        s = text
+        while i < len(s):
+            if s[i].isspace():
+                if out and out[-1] != " ":
+                    out.append(" ")
+                i += 1
+                continue
+            for tok in tokens:
+                if s.startswith(tok, i):
+                    if out and out[-1] != " ":
+                        out.append(" ")
+                    out.append(tok)
+                    i += len(tok)
+                    break
+            else:
+                # Unknown character (shouldn't happen for valid inputs);
+                # pass through verbatim to avoid swallowing data.
+                out.append(s[i])
+                i += 1
+        return "".join(out).strip()
 
     def verify_cardinal(self, value):
         iscardinal = True

--- a/tests/lang/test_tr.py
+++ b/tests/lang/test_tr.py
@@ -413,3 +413,25 @@ def test_tr_bir_inserted_between_hundred_and_thousand_in_6_digit_numbers():
     assert num2words(201605, lang="tr") == "ikiyüzbirbinaltıyüzbeş"
     # 1×1000 still suppresses 'bir' (canonical Turkish)
     assert num2words(1100, lang="tr") == "binyüz"
+
+
+def test_tr_spaced_precision_decimal_word_kwargs():
+    # Regression for num2words2#64 part 2/3 (ports savoirfairelinux/num2words#486+#534).
+    from num2words2 import num2words
+
+    # Default unchanged: concatenated, virgül, precision=2
+    assert num2words(1234, lang="tr") == "binikiyüzotuzdört"
+    assert num2words(1.5, lang="tr") == "birvirgülelli"
+
+    # spaced=True splits on Turkish word boundaries
+    assert num2words(1234, lang="tr", spaced=True) == "bin iki yüz otuz dört"
+    assert num2words(401607, lang="tr", spaced=True) == "dört yüz bir bin altı yüz yedi"
+
+    # precision= controls fractional-digit count
+    assert num2words(3.14159, lang="tr", precision=5) == "üçvirgülondörtbinyüzellidokuz"
+
+    # decimal_word= swaps virgül for any chosen word
+    assert num2words(1.5, lang="tr", decimal_word="nokta") == "birnoktaelli"
+
+    # Combined
+    assert num2words(3.14, lang="tr", spaced=True, decimal_word="nokta") == "üç nokta on dört"


### PR DESCRIPTION
Closes the remaining items in #64 (ports savoirfairelinux/num2words#486 + #534).

```python
>>> num2words(1234, lang='tr', spaced=True)
'bin iki yüz otuz dört'
>>> num2words(3.14159, lang='tr', precision=5)
'üçvirgülondörtbinyüzellidokuz'
>>> num2words(1.5, lang='tr', decimal_word='nokta')
'birnoktaelli'
>>> num2words(3.14, lang='tr', spaced=True, decimal_word='nokta')
'üç nokta on dört'
```

All three default to the previous behavior — no existing callers affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)