### PR TITLE
feat: v1.0.6 API polish — maxval(), python -m, precision= kwarg

### DIFF
--- a/num2words2/__init__.py
+++ b/num2words2/__init__.py
@@ -194,6 +194,28 @@ except ImportError:
 
 from .grouping import group_digits  # noqa: E402
 
+
+def maxval(lang="en"):
+    """Return the maximum integer ``num2words(..., lang=lang)`` can convert.
+
+    Issue #582 ports savoirfairelinux/num2words#582. Useful for input
+    validation in apps that need to know the per-language ceiling before
+    calling :func:`num2words`.
+    """
+    if lang not in CONVERTER_CLASSES:
+        # Reuse the same prefix-fallback the dispatcher does so callers
+        # don't have to know the canonical key.
+        nl = lang.replace("-", "_")
+        if nl in CONVERTER_CLASSES:
+            lang = nl
+        elif nl[:2] in CONVERTER_CLASSES:
+            lang = nl[:2]
+        else:
+            raise NotImplementedError("No MAXVAL for lang=%r" % lang)
+    converter = CONVERTER_CLASSES[lang]
+    return getattr(converter, "MAXVAL", None)
+
+
 # Export main functions
 __all__ = [
     "num2words",
@@ -201,6 +223,7 @@ __all__ = [
     "convert_sentence",
     "sentence_to_words",
     "group_digits",
+    "maxval",
 ]
 
 
@@ -419,7 +442,20 @@ def num2words(number, ordinal=False, lang="en", to="cardinal", **kwargs):
     if to not in CONVERTES_TYPES:
         raise NotImplementedError()
 
-    return getattr(converter, "to_{}".format(to))(number, **kwargs)
+    # precision= overrides the per-language fractional precision for this
+    # call. Issue #580 ports savoirfairelinux/num2words#580. Most language
+    # to_cardinal methods don't accept the kwarg, so apply it as a temporary
+    # attribute swap on the converter instead of forwarding.
+    precision_override = kwargs.pop("precision", None)
+    saved_precision = None
+    if precision_override is not None and hasattr(converter, "precision"):
+        saved_precision = converter.precision
+        converter.precision = int(precision_override)
+    try:
+        return getattr(converter, "to_{}".format(to))(number, **kwargs)
+    finally:
+        if saved_precision is not None:
+            converter.precision = saved_precision
 
 
 def num2words_sentence(sentence, lang="en", to="cardinal", **kwargs):

--- a/num2words2/__main__.py
+++ b/num2words2/__main__.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, num2words2 contributors. All Rights Reserved.
+# Licensed under LGPL-2.1 (see COPYING).
+"""Allow ``python -m num2words2`` invocation. Issue #348."""
+from __future__ import print_function, unicode_literals
+
+import argparse
+import sys
+
+import num2words2
+
+
+def main():
+    p = argparse.ArgumentParser(prog="num2words2", description="Convert numbers to words.")
+    p.add_argument("number", nargs="?", help="number to convert")
+    p.add_argument("-l", "--lang", default="en", help="language code (default: en)")
+    p.add_argument("--to", default="cardinal", help="cardinal/ordinal/year/currency")
+    p.add_argument("--list-languages", action="store_true")
+    p.add_argument("--list-converters", action="store_true")
+    args = p.parse_args()
+    if args.list_languages:
+        for lang in sorted(num2words2.CONVERTER_CLASSES):
+            print(lang)
+        return 0
+    if args.list_converters:
+        for cvt in sorted(num2words2.CONVERTES_TYPES):
+            print(cvt)
+        return 0
+    if args.number is None:
+        p.print_help()
+        return 1
+    try:
+        print(num2words2.num2words(args.number, lang=args.lang, to=args.to))
+        return 0
+    except Exception as err:
+        print("{}: {}".format(args.number, err), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/num2words2/base.py
+++ b/num2words2/base.py
@@ -138,29 +138,37 @@ class Num2Word_Base(object):
 
         return pre, post
 
-    def to_cardinal_float(self, value):
+    def to_cardinal_float(self, value, precision=None):
         try:
             float(value) == value
         except (ValueError, TypeError, AssertionError, AttributeError):
             raise TypeError(self.errmsg_nonnum % value)
 
-        pre, post = self.float2tuple(float(value))
+        # Caller-supplied precision overrides the per-instance default.
+        # Issue #580 ports savoirfairelinux/num2words#580.
+        saved_precision = self.precision
+        if precision is not None:
+            self.precision = int(precision)
+        try:
+            pre, post = self.float2tuple(float(value))
 
-        post = str(post)
-        post = "0" * (self.precision - len(post)) + post
+            post = str(post)
+            post = "0" * (self.precision - len(post)) + post
 
-        out = [self.to_cardinal(pre)]
-        if value < 0 and pre == 0:
-            out = [self.negword.strip()] + out
+            out = [self.to_cardinal(pre)]
+            if value < 0 and pre == 0:
+                out = [self.negword.strip()] + out
 
-        if self.precision:
-            out.append(self.title(self.pointword))
+            if self.precision:
+                out.append(self.title(self.pointword))
 
-        for i in range(self.precision):
-            curr = int(post[i])
-            out.append(to_s(self.to_cardinal(curr)))
+            for i in range(self.precision):
+                curr = int(post[i])
+                out.append(to_s(self.to_cardinal(curr)))
 
-        return " ".join(out)
+            return " ".join(out)
+        finally:
+            self.precision = saved_precision
 
     def merge(self, curr, next):
         raise NotImplementedError

--- a/tests/test_v106_features.py
+++ b/tests/test_v106_features.py
@@ -1,0 +1,42 @@
+"""Tier-1 v1.0.6 features: maxval helper, runpy entry, precision= kwarg."""
+
+import subprocess
+import sys
+
+import pytest
+
+import num2words2
+
+
+def test_maxval_helper():
+    # Issue #582
+    assert isinstance(num2words2.maxval("en"), int)
+    assert num2words2.maxval("en") > 10**100
+    assert num2words2.maxval("en_IN") > 10**18
+    # Unknown lang raises
+    with pytest.raises(NotImplementedError):
+        num2words2.maxval("zzz_unknown")
+
+
+def test_runpy_invocation():
+    # Issue #348 — python -m num2words2 N -l X
+    out = subprocess.check_output(
+        [sys.executable, "-m", "num2words2", "1234", "-l", "fr"]
+    ).decode().strip()
+    assert out == "mille deux cent trente-quatre"
+
+
+def test_runpy_list_languages():
+    out = subprocess.check_output(
+        [sys.executable, "-m", "num2words2", "--list-languages"]
+    ).decode()
+    assert "en" in out.split()
+    assert "fr" in out.split()
+
+
+def test_precision_kwarg():
+    # Issue #580 — precision= overrides default 2-digit fractional precision.
+    assert num2words2.num2words(3.14159, lang="en", precision=5) == \
+        "three point one four one five nine"
+    # Default precision (2) unchanged when no kwarg.
+    assert num2words2.num2words(3.14, lang="en") == "three point one four"


### PR DESCRIPTION
Three Tier-1 features from upstream triage:

- `num2words2.maxval(lang='en')` (#582)
- `python -m num2words2 ...` runpy entry (#348)
- `precision=N` kwarg on `num2words()` (#580)

`cents=False` deferred to v1.0.7 (existing tests rely on different semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)