### PR TITLE
feat: v1.0.7 — cents=omit + style=terse ordinals

### DIFF
--- a/num2words2/__init__.py
+++ b/num2words2/__init__.py
@@ -443,19 +443,50 @@ def num2words(number, ordinal=False, lang="en", to="cardinal", **kwargs):
         raise NotImplementedError()
 
     # precision= overrides the per-language fractional precision for this
-    # call. Issue #580 ports savoirfairelinux/num2words#580. Most language
-    # to_cardinal methods don't accept the kwarg, so apply it as a temporary
-    # attribute swap on the converter instead of forwarding.
+    # call. Issue #580 ports savoirfairelinux/num2words#580.
     precision_override = kwargs.pop("precision", None)
     saved_precision = None
     if precision_override is not None and hasattr(converter, "precision"):
         saved_precision = converter.precision
         converter.precision = int(precision_override)
+
+    # cents='omit' on to='currency' drops the cents portion entirely. The
+    # legacy cents=True/False kwarg is kept as-is (False historically meant
+    # "use digits instead of words"). Issue #554 ports
+    # savoirfairelinux/num2words#554 / #190.
+    cents_mode = None
+    if to == "currency":
+        cents_kw = kwargs.get("cents")
+        if cents_kw == "omit":
+            cents_mode = "omit"
+            kwargs["cents"] = True  # let downstream see a valid bool
+            if isinstance(number, float):
+                number = int(number)  # int path drops cents naturally
+        elif cents_kw == "verbose":
+            kwargs["cents"] = True
+        elif cents_kw == "terse":
+            kwargs["cents"] = False
+
+    # style='terse' on to='ordinal' drops the leading 'one' / 'un' / etc.
+    # Issue #535 ports savoirfairelinux/num2words#535 / #147.
+    style = kwargs.pop("style", None)
+
     try:
-        return getattr(converter, "to_{}".format(to))(number, **kwargs)
+        result = getattr(converter, "to_{}".format(to))(number, **kwargs)
     finally:
         if saved_precision is not None:
             converter.precision = saved_precision
+
+    if style == "terse" and to == "ordinal" and isinstance(result, str):
+        # Drop a leading "one " / "un " / "uno " prefix that's stylistic.
+        # 100 → "one hundredth" → "hundredth"; 1000 → "one thousandth" →
+        # "thousandth"; the same applies to fr's "un millionième" but
+        # that's already handled in lang_FR's _BIG_UNITS.
+        for prefix in ("one ", "un ", "uno "):
+            if result.startswith(prefix) and len(result) > len(prefix):
+                result = result[len(prefix):]
+                break
+    return result
 
 
 def num2words_sentence(sentence, lang="en", to="cardinal", **kwargs):

--- a/tests/test_v107_features.py
+++ b/tests/test_v107_features.py
@@ -1,0 +1,38 @@
+"""Tier-2 v1.0.7 features: cents=mode and style='terse'."""
+
+from num2words2 import num2words
+
+
+def test_cents_omit_drops_cents_portion():
+    # Issue #554 / #190
+    assert num2words(55.45, lang="en", to="currency", cents="omit") == "fifty-five euros"
+    assert num2words(100.99, lang="en", to="currency", cents="omit") == "one hundred euros"
+
+
+def test_cents_verbose_full_words():
+    # 'verbose' alias = legacy True
+    assert num2words(55.45, lang="en", to="currency", cents="verbose") == \
+        "fifty-five euros, forty-five cents"
+
+
+def test_cents_terse_keeps_legacy_digit_form():
+    # 'terse' alias = legacy False (digits for cents)
+    assert "45" in num2words(55.45, lang="en", to="currency", cents="terse")
+
+
+def test_legacy_cents_bool_unchanged():
+    # cents=True/False legacy semantics unchanged.
+    assert num2words(55.45, lang="en", to="currency", cents=True) == \
+        "fifty-five euros, forty-five cents"
+
+
+def test_terse_ordinal_drops_leading_one():
+    # Issue #535 / #147
+    assert num2words(100, ordinal=True, lang="en", style="terse") == "hundredth"
+    assert num2words(1000, ordinal=True, lang="en", style="terse") == "thousandth"
+    # 1 stays "first" (not stripped because it's exactly "first")
+    assert num2words(1, ordinal=True, lang="en", style="terse") == "first"
+
+
+def test_terse_ordinal_default_unchanged():
+    assert num2words(100, ordinal=True, lang="en") == "one hundredth"


### PR DESCRIPTION
Closes upstream #554/#190 (cents='omit'/'verbose'/'terse') and #535/#147 (style='terse' ordinals).

```python
>>> num2words(55.45, lang='en', to='currency', cents='omit')
'fifty-five euros'
>>> num2words(100, ordinal=True, lang='en', style='terse')
'hundredth'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)