### PR TITLE
feat: v1.0.8 — style='us' for American English (no 'and')

### DIFF
--- a/num2words2/__init__.py
+++ b/num2words2/__init__.py
@@ -486,6 +486,11 @@ def num2words(number, ordinal=False, lang="en", to="cardinal", **kwargs):
             if result.startswith(prefix) and len(result) > len(prefix):
                 result = result[len(prefix):]
                 break
+    if style == "us" and lang.startswith("en") and isinstance(result, str):
+        # American English drops 'and' between hundreds and tens
+        # ("two hundred fifty" not "two hundred and fifty"). Issue #562
+        # ports savoirfairelinux/num2words#562 by @granvillebarker.
+        result = result.replace(" and ", " ")
     return result
 
 

--- a/tests/test_v108_features.py
+++ b/tests/test_v108_features.py
@@ -1,0 +1,12 @@
+"""v1.0.8: style='us' drops 'and' in English."""
+from num2words2 import num2words
+
+def test_us_drops_and_in_cardinal():
+    assert num2words(1234, lang="en", style="us") == "one thousand, two hundred thirty-four"
+    assert num2words(250, lang="en", style="us") == "two hundred fifty"
+
+def test_us_drops_and_in_ordinal():
+    assert num2words(101, ordinal=True, lang="en", style="us") == "one hundred first"
+
+def test_us_default_unchanged():
+    assert num2words(1234, lang="en") == "one thousand, two hundred and thirty-four"


### PR DESCRIPTION
Closes upstream #562 by @granvillebarker.

```python
>>> num2words(1234, lang='en', style='us')
'one thousand, two hundred thirty-four'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)