### PR TITLE
feat(currency): 3-decimal mils (#256) + bank cheque format (#364)

### DIFF
--- a/num2words2/__init__.py
+++ b/num2words2/__init__.py
@@ -385,7 +385,9 @@ CONVERTER_CLASSES = {
     "dk": lang_DA.Num2Word_DA(),  # Pre-ISO-639 code for Danish (ISO is 'da')
 }
 
-CONVERTES_TYPES = ["cardinal", "ordinal", "ordinal_num", "year", "currency"]
+CONVERTES_TYPES = [
+    "cardinal", "ordinal", "ordinal_num", "year", "currency", "cheque",
+]
 CONVERTER_TYPES = CONVERTES_TYPES  # Alias for compatibility
 
 

--- a/num2words2/base.py
+++ b/num2words2/base.py
@@ -28,6 +28,11 @@ from .currency import parse_currency_parts, prefix_currency
 class Num2Word_Base(object):
     CURRENCY_FORMS = {}
     CURRENCY_ADJECTIVES = {}
+    # Number of fractional subunits per main unit. Default 100 (cents).
+    # Currencies with non-cent subdivisions override per-code: 3-decimal
+    # currencies use 1000 (mils); 0-decimal currencies use 1.
+    # Issue #256 ports savoirfairelinux/num2words#256.
+    CURRENCY_PRECISION = {}
 
     def __init__(self):
         self.is_title = False
@@ -299,7 +304,59 @@ class Num2Word_Base(object):
         return self.to_cardinal(number)
 
     def _cents_terse(self, number, currency):
-        return "%02d" % number
+        # Width follows the currency's subunit precision: 2 for cents
+        # (default), 3 for mils (TND/BHD/KWD/etc.). Issue #256.
+        divisor = self.CURRENCY_PRECISION.get(currency, 100)
+        if divisor <= 1:
+            return "%d" % int(number)
+        width = len(str(divisor)) - 1
+        return "%0*d" % (width, int(number))
+
+    def to_cheque(self, val, currency="USD"):
+        """Bank-cheque format: ``ONE THOUSAND AND 56/100 DOLLARS``.
+
+        Standard convention is the integer part written out as words, the
+        word "AND", the fractional part as digits over the divisor (e.g.
+        56/100 for cents, 005/1000 for mils), and the plural currency
+        name. The whole thing is upper-cased per banking style. Issue
+        #364 ports savoirfairelinux/num2words#364.
+        """
+        from decimal import Decimal
+
+        try:
+            cr1, _cr2 = self.CURRENCY_FORMS[currency]
+        except KeyError:
+            raise NotImplementedError(
+                'Currency code "%s" not implemented for "%s"'
+                % (currency, self.__class__.__name__)
+            )
+
+        divisor = self.CURRENCY_PRECISION.get(currency, 100)
+        decimal_val = Decimal(str(val))
+        is_negative = decimal_val < 0
+        abs_val = abs(decimal_val)
+
+        whole = int(abs_val)
+        # Pull the fractional subunit out at the currency's precision.
+        if divisor > 1:
+            sub = int((abs_val - whole) * divisor)
+            digits = len(str(divisor)) - 1
+            fraction_str = "%0*d/%d" % (digits, sub, divisor)
+        else:
+            fraction_str = ""
+
+        words = self._money_verbose(whole, currency)
+        # Cheque convention always uses the plural currency name
+        # ("ONE AND 00/100 DOLLARS", not "...DOLLAR"), so we take the
+        # plural form unconditionally.
+        unit = cr1[-1] if isinstance(cr1, tuple) else cr1
+
+        sign = "MINUS " if is_negative else ""
+        if fraction_str:
+            body = "%s AND %s %s" % (words, fraction_str, unit)
+        else:
+            body = "%s %s" % (words, unit)
+        return (sign + body).upper()
 
     def to_currency(
         self, val, currency="EUR", cents=True, separator=",", adjective=False
@@ -316,6 +373,13 @@ class Num2Word_Base(object):
 
         Handles whole numbers and decimal numbers differently
         """
+        # Zero-decimal currencies (JPY, KRW, ...) have no subunit, so any
+        # fractional input is rounded to a whole unit and the result skips
+        # the cents segment entirely. Issue #256.
+        if self.CURRENCY_PRECISION.get(currency, 100) == 1 and not isinstance(val, int):
+            from decimal import ROUND_HALF_UP, Decimal
+            val = int(Decimal(str(val)).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
         # Handle integers separately - no cents shown
         # Only pure integers, NOT floats that happen to be whole numbers
         if isinstance(val, int):
@@ -336,15 +400,20 @@ class Num2Word_Base(object):
 
             return "%s%s %s" % (minus_str, money_str, self.pluralize(abs(val_int), cr1))
 
-        # For floats, show full currency with cents
-        # Check if value has more than 2 decimal places
+        # For floats, show full currency with subunits (cents/mils/etc.)
+        # The divisor is per-currency: 100 (cents) by default, 1000 (mils)
+        # for 3-decimal currencies, 1 for no-subunit currencies. Issue #256.
         from decimal import Decimal
 
+        divisor = self.CURRENCY_PRECISION.get(currency, 100)
         decimal_val = Decimal(str(val))
-        has_fractional_cents = (decimal_val * 100) % 1 != 0
+        has_fractional_cents = (decimal_val * divisor) % 1 != 0
 
         left, right, is_negative = parse_currency_parts(
-            val, is_int_with_cents=False, keep_precision=has_fractional_cents
+            val,
+            is_int_with_cents=False,
+            keep_precision=has_fractional_cents,
+            divisor=divisor,
         )
 
         try:

--- a/num2words2/currency.py
+++ b/num2words2/currency.py
@@ -20,13 +20,24 @@ from __future__ import division
 from decimal import ROUND_HALF_UP, Decimal
 
 
-def parse_currency_parts(value, is_int_with_cents=True, keep_precision=False):
+def parse_currency_parts(
+    value, is_int_with_cents=True, keep_precision=False, divisor=100
+):
+    """Split ``value`` into integer-part, fractional-subunit-part, sign.
+
+    The default divisor of 100 corresponds to 2-decimal currencies
+    (USD/EUR cents). Pass ``divisor=1000`` for 3-decimal currencies
+    such as Tunisian/Bahraini/Kuwaiti/Omani/Jordanian/Libyan/Iraqi
+    dinars (1 dinar = 1000 millimes/fils). Pass ``divisor=1`` for
+    no-subunit currencies like JPY/KRW/VND. Issue #256 ports
+    savoirfairelinux/num2words#256.
+    """
     if isinstance(value, int):
         if is_int_with_cents:
-            # assume cents if value is integer
+            # assume cents (or whatever subunit divisor implies)
             negative = value < 0
             value = abs(value)
-            integer, cents = divmod(value, 100)
+            integer, cents = divmod(value, divisor) if divisor else (value, 0)
         else:
             negative = value < 0
             integer, cents = abs(value), 0
@@ -35,9 +46,11 @@ def parse_currency_parts(value, is_int_with_cents=True, keep_precision=False):
         # Convert to string first to avoid float precision issues
         value = Decimal(str(value))
 
-        if not keep_precision:
-            # Round to 2 decimal places
-            value = value.quantize(Decimal(".01"), rounding=ROUND_HALF_UP)
+        if not keep_precision and divisor > 1:
+            # Round to the precision implied by the divisor: 100 → .01,
+            # 1000 → .001, etc. quant must be a Decimal power-of-ten.
+            quant = Decimal(1) / Decimal(divisor)
+            value = value.quantize(quant, rounding=ROUND_HALF_UP)
 
         negative = value < 0
         value = abs(value)
@@ -45,10 +58,9 @@ def parse_currency_parts(value, is_int_with_cents=True, keep_precision=False):
         integer = int(integer)
 
         if keep_precision:
-            # Keep full precision for cents
-            cents = fraction * 100  # Keep as Decimal
+            cents = fraction * divisor  # keep as Decimal
         else:
-            cents = int(fraction * 100)
+            cents = int(fraction * divisor)
 
     return integer, cents, negative
 

--- a/num2words2/lang_EN.py
+++ b/num2words2/lang_EN.py
@@ -46,6 +46,22 @@ class Num2Word_EN(lang_EUR.Num2Word_EUR):
         self.CURRENCY_FORMS["SAR"] = (("riyal", "riyals"), ("halalah", "halalas"))
         self.CURRENCY_FORMS["QAR"] = (("riyal", "riyals"), ("dirham", "dirhams"))
         self.CURRENCY_FORMS["KWD"] = (("dinar", "dinars"), ("fils", "fils"))
+        # 3-decimal currencies (mils as subunit). Issue #256 ports
+        # savoirfairelinux/num2words#256.
+        self.CURRENCY_FORMS["BHD"] = (("dinar", "dinars"), ("fils", "fils"))
+        self.CURRENCY_FORMS["OMR"] = (("rial", "rials"), ("baisa", "baisa"))
+        self.CURRENCY_FORMS["JOD"] = (("dinar", "dinars"), ("fils", "fils"))
+        self.CURRENCY_FORMS["TND"] = (("dinar", "dinars"), ("millime", "millimes"))
+        self.CURRENCY_FORMS["LYD"] = (("dinar", "dinars"), ("dirham", "dirhams"))
+        self.CURRENCY_FORMS["IQD"] = (("dinar", "dinars"), ("fils", "fils"))
+        # Per-currency subunit precision (1000 = 3-decimal mils). Currencies
+        # not listed default to 100 (cents). JPY/KRW are kept at the default
+        # because their historical sen/jeon subunits are still expected by
+        # the test fixtures even though no longer in everyday use.
+        self.CURRENCY_PRECISION = {
+            "BHD": 1000, "KWD": 1000, "OMR": 1000, "JOD": 1000,
+            "TND": 1000, "LYD": 1000, "IQD": 1000,
+        }
 
     def set_high_numwords(self, high):
         max = 3 + 3 * len(high)

--- a/tests/test_currency_3decimal_and_cheque.py
+++ b/tests/test_currency_3decimal_and_cheque.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+"""Coverage for the two currency features deferred until v1.0.12.
+
+- savoirfairelinux/num2words#256 — 3-decimal currencies (BHD/KWD/TND/...).
+  The subunit is mils (1/1000) instead of cents (1/100). Driven by a
+  per-currency ``CURRENCY_PRECISION`` map and a ``divisor`` argument
+  threaded through ``parse_currency_parts``.
+
+- savoirfairelinux/num2words#364 — cheque format. New ``to='cheque'``
+  conversion type emits the bank-style "ONE THOUSAND AND 56/100 DOLLARS"
+  formatting. Uses the same per-currency precision so a BHD cheque ends
+  with ``234/1000 DINARS``.
+"""
+from __future__ import unicode_literals
+
+import unittest
+
+from num2words2 import num2words
+
+
+class TestThreeDecimalCurrency(unittest.TestCase):
+    """savoirfairelinux/num2words#256 — 3-decimal currencies."""
+
+    def test_bhd_with_mils(self):
+        self.assertEqual(
+            num2words(5.123, lang="en", to="currency", currency="BHD"),
+            "five dinars, one hundred and twenty-three fils",
+        )
+
+    def test_kwd_with_mils(self):
+        self.assertEqual(
+            num2words(1.500, lang="en", to="currency", currency="KWD"),
+            "one dinar, five hundred fils",
+        )
+
+    def test_tnd_millimes(self):
+        self.assertEqual(
+            num2words(0.001, lang="en", to="currency", currency="TND"),
+            "zero dinars, one millime",
+        )
+
+    def test_omr_baisa(self):
+        self.assertEqual(
+            num2words(2.250, lang="en", to="currency", currency="OMR"),
+            "two rials, two hundred and fifty baisa",
+        )
+
+    def test_jod_fils(self):
+        self.assertEqual(
+            num2words(10.005, lang="en", to="currency", currency="JOD"),
+            "ten dinars, five fils",
+        )
+
+    def test_lyd_dirhams(self):
+        out = num2words(3.999, lang="en", to="currency", currency="LYD")
+        self.assertIn("dinars", out)
+        self.assertIn("dirhams", out)
+
+    def test_iqd_fils(self):
+        self.assertEqual(
+            num2words(1.000, lang="en", to="currency", currency="IQD"),
+            "one dinar, zero fils",
+        )
+
+    def test_three_decimal_integer_no_cents(self):
+        # Pure int input doesn't show the subunit segment.
+        self.assertEqual(
+            num2words(5, lang="en", to="currency", currency="BHD"),
+            "five dinars",
+        )
+
+    def test_two_decimal_unchanged(self):
+        # Default precision (cents) is preserved.
+        self.assertEqual(
+            num2words(1.05, lang="en", to="currency", currency="EUR"),
+            "one euro, five cents",
+        )
+        self.assertEqual(
+            num2words(1234.56, lang="en", to="currency", currency="USD"),
+            "one thousand, two hundred and thirty-four dollars, fifty-six cents",
+        )
+
+    def test_negative_three_decimal(self):
+        self.assertTrue(
+            num2words(-1.500, lang="en", to="currency", currency="BHD").startswith(
+                "minus"
+            )
+        )
+
+    def test_unknown_currency_still_raises(self):
+        with self.assertRaises(NotImplementedError):
+            num2words(5.0, lang="en", to="currency", currency="ZZZ")
+
+
+class TestChequeFormat(unittest.TestCase):
+    """savoirfairelinux/num2words#364 — bank cheque format."""
+
+    def test_basic_usd(self):
+        self.assertEqual(
+            num2words(1234.56, lang="en", to="cheque", currency="USD"),
+            "ONE THOUSAND, TWO HUNDRED AND THIRTY-FOUR AND 56/100 DOLLARS",
+        )
+
+    def test_zero_cents(self):
+        self.assertEqual(
+            num2words(1.00, lang="en", to="cheque", currency="USD"),
+            "ONE AND 00/100 DOLLARS",
+        )
+
+    def test_zero_value(self):
+        self.assertEqual(
+            num2words(0, lang="en", to="cheque", currency="USD"),
+            "ZERO AND 00/100 DOLLARS",
+        )
+
+    def test_pure_integer(self):
+        # Integer input still gets the cheque-style /100 suffix.
+        self.assertEqual(
+            num2words(1, lang="en", to="cheque", currency="USD"),
+            "ONE AND 00/100 DOLLARS",
+        )
+
+    def test_million(self):
+        self.assertEqual(
+            num2words(1_000_000.99, lang="en", to="cheque", currency="USD"),
+            "ONE MILLION AND 99/100 DOLLARS",
+        )
+
+    def test_currency_pluralised_for_one(self):
+        # Cheque convention writes plural "DOLLARS" even for $1.
+        out = num2words(1.00, lang="en", to="cheque", currency="USD")
+        self.assertIn("DOLLARS", out)
+        self.assertNotIn("DOLLAR ", out)
+
+    def test_negative(self):
+        out = num2words(-12.50, lang="en", to="cheque", currency="EUR")
+        self.assertTrue(out.startswith("MINUS"))
+        self.assertIn("50/100", out)
+
+    def test_three_decimal_currency_on_cheque(self):
+        # Cheque format respects the per-currency precision: 3-decimal
+        # mils get xxx/1000 instead of xx/100.
+        self.assertEqual(
+            num2words(1.234, lang="en", to="cheque", currency="BHD"),
+            "ONE AND 234/1000 DINARS",
+        )
+
+    def test_indian_rupees(self):
+        self.assertEqual(
+            num2words(100, lang="en", to="cheque", currency="INR"),
+            "ONE HUNDRED AND 00/100 RUPEES",
+        )
+
+    def test_unknown_currency_raises(self):
+        with self.assertRaises(NotImplementedError):
+            num2words(1.0, lang="en", to="cheque", currency="ZZZ")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Two upstream deferred features, shipped together because they share the same per-currency precision plumbing.

### [#256](https://github.com/savoirfairelinux/num2words/issues/256) — 3-decimal currencies

Currencies with 1000-mil subunits now round-trip cleanly through \`to_currency\`:

```python
>>> num2words(5.123, lang='en', to='currency', currency='BHD')
'five dinars, one hundred and twenty-three fils'
>>> num2words(0.001, lang='en', to='currency', currency='TND')
'zero dinars, one millime'
>>> num2words(2.250, lang='en', to='currency', currency='OMR')
'two rials, two hundred and fifty baisa'
```

Supported codes: **BHD, KWD, OMR, JOD, TND, LYD, IQD**.

Driven by:
- \`parse_currency_parts\` gains a \`divisor=\` parameter (defaults 100)
- \`Num2Word_Base.CURRENCY_PRECISION\` per-currency override map
- \`to_currency\` reads the divisor and quantizes accordingly

### [#364](https://github.com/savoirfairelinux/num2words/issues/364) — bank cheque format

New \`to='cheque'\` mode emits standard banking style:

```python
>>> num2words(1234.56, lang='en', to='cheque', currency='USD')
'ONE THOUSAND, TWO HUNDRED AND THIRTY-FOUR AND 56/100 DOLLARS'
>>> num2words(1.00, lang='en', to='cheque', currency='USD')
'ONE AND 00/100 DOLLARS'
>>> num2words(-12.50, lang='en', to='cheque', currency='EUR')
'MINUS TWELVE AND 50/100 EUROS'
>>> num2words(1.234, lang='en', to='cheque', currency='BHD')
'ONE AND 234/1000 DINARS'
```

Composition: cheque format reads the same per-currency precision so a BHD cheque ends in \`234/1000 DINARS\` (3-decimal mils) instead of \`/100\`.

## Test plan
- [x] \`tests/test_currency_3decimal_and_cheque.py\` — 21 cases (all 7 mil currencies, integer/float/negative inputs, plural-form edge cases, unknown-currency raise)
- [x] Full unittest suite passes (2924 tests)
- [x] flake8 + isort clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)