### PR TITLE
feat(fraction): add to_fraction + 'n/d' string routing (#584)

### DIFF
--- a/num2words2/__init__.py
+++ b/num2words2/__init__.py
@@ -387,6 +387,7 @@ CONVERTER_CLASSES = {
 
 CONVERTES_TYPES = [
     "cardinal", "ordinal", "ordinal_num", "year", "currency", "cheque",
+    "fraction",
 ]
 CONVERTER_TYPES = CONVERTES_TYPES  # Alias for compatibility
 
@@ -415,6 +416,24 @@ def num2words(number, ordinal=False, lang="en", to="cardinal", **kwargs):
     converter = CONVERTER_CLASSES[lang]
 
     if isinstance(number, str):
+        # Recognize "n/d" fraction strings and route directly to the
+        # converter's to_fraction(). The pattern is strict: optional
+        # leading minus, integer numerator, single '/', integer
+        # denominator, no whitespace inside. Issue #75 ports
+        # savoirfairelinux/num2words#584.
+        stripped = number.strip()
+        if "/" in stripped and stripped.count("/") == 1:
+            num_part, den_part = stripped.split("/", 1)
+            num_part = num_part.strip()
+            den_part = den_part.strip()
+            try:
+                num_int = int(num_part)
+                den_int = int(den_part)
+            except ValueError:
+                pass
+            else:
+                return converter.to_fraction(num_int, den_int)
+
         # If the string is a mix of text and numerals (e.g. "text 1"),
         # route to num2words_sentence which extracts numerals and converts
         # each in place. A pure-text string like "hello" still raises so

--- a/num2words2/base.py
+++ b/num2words2/base.py
@@ -290,6 +290,29 @@ class Num2Word_Base(object):
     def to_year(self, value, **kwargs):
         return self.to_cardinal(value)
 
+    def to_fraction(self, numerator, denominator):
+        """Render ``numerator/denominator`` as words.
+
+        Default is "<cardinal numerator> <ordinal denominator>[s]" — e.g.
+        ``2/5`` → "two fifths". Languages with idiomatic forms for
+        common denominators (English half/quarter, French demi/tiers,
+        German Drittel/Viertel, ...) override this. Issue #584 ports
+        savoirfairelinux/num2words#584.
+        """
+        if denominator == 0:
+            raise ZeroDivisionError("denominator must not be zero")
+        if denominator == 1 or numerator == 0:
+            return self.to_cardinal(numerator)
+        is_negative = (numerator < 0) ^ (denominator < 0)
+        abs_n = abs(int(numerator))
+        abs_d = abs(int(denominator))
+        sign = "%s " % self.negword.strip() if is_negative else ""
+        num_word = self.to_cardinal(abs_n)
+        den_word = self.to_ordinal(abs_d)
+        if abs_n != 1:
+            den_word = den_word + "s"  # languages override for proper plural
+        return sign + num_word + " " + den_word
+
     def pluralize(self, n, forms):
         """
         Should resolve gettext form:

--- a/num2words2/lang_DE.py
+++ b/num2words2/lang_DE.py
@@ -203,6 +203,61 @@ class Num2Word_DE(Num2Word_EUR):
         self.verify_ordinal(value)
         return str(value) + "."
 
+    def to_fraction(self, numerator, denominator):
+        """German fractions: capitalised noun, invariant plural.
+
+        ``1/3`` → "ein Drittel"; ``2/3`` → "zwei Drittel" (no -s plural).
+        ``1/2`` → "ein halb"; ``2/2`` → "zwei halbe" (adjectival).
+        Numerator uses the apocopated ``ein`` rather than the cardinal
+        ``eins`` since the fraction is a noun phrase. Issue #584.
+        """
+        if denominator == 0:
+            raise ZeroDivisionError("denominator must not be zero")
+        if denominator == 1 or numerator == 0:
+            return self.to_cardinal(numerator)
+        is_negative = (numerator < 0) ^ (denominator < 0)
+        abs_n = abs(int(numerator))
+        abs_d = abs(int(denominator))
+
+        # Common denominators with their idiomatic noun. Plural is
+        # invariant for these — "zwei Drittel" not "zwei Drittels".
+        de_frac = {
+            3: "Drittel",
+            4: "Viertel",
+            5: "Fünftel",
+            6: "Sechstel",
+            7: "Siebtel",
+            8: "Achtel",
+            9: "Neuntel",
+            10: "Zehntel",
+            11: "Elftel",
+            12: "Zwölftel",
+        }
+        if abs_d == 2:
+            den_word = "halb" if abs_n == 1 else "halbe"
+        elif abs_d in de_frac:
+            den_word = de_frac[abs_d]
+        elif abs_d < 20:
+            stem = self.to_cardinal(abs_d)
+            den_word = stem + "tel"
+            den_word = den_word[0].upper() + den_word[1:]
+        else:
+            # 20+ → cardinal + 'stel' (zwanzigstel, hundertstel, ...).
+            stem = self.to_cardinal(abs_d)
+            # Drop the redundant 'ein' prefix on round powers of ten:
+            # 100 reads as 'einhundert' standalone but 'Hundertstel' as
+            # a fraction noun; same for 'eintausend' → 'Tausendstel'.
+            for prefix in ("einhundert", "eintausend", "einemillion", "einemilliarde"):
+                if stem.startswith(prefix) and stem == prefix:
+                    stem = stem[3:]  # drop 'ein'
+                    break
+            den_word = stem + "stel"
+            den_word = den_word[0].upper() + den_word[1:]
+
+        num_word = "ein" if abs_n == 1 else self.to_cardinal(abs_n)
+        sign = "%s " % self.negword.strip() if is_negative else ""
+        return sign + num_word + " " + den_word
+
     def to_currency(
         self, val, currency="EUR", cents=True, separator=" und", adjective=False
     ):

--- a/num2words2/lang_EN.py
+++ b/num2words2/lang_EN.py
@@ -168,6 +168,37 @@ class Num2Word_EN(lang_EUR.Num2Word_EUR):
         self.verify_ordinal(value)
         return "%s%s" % (value, self.to_ordinal(value)[-2:])
 
+    def to_fraction(self, numerator, denominator):
+        """English fraction with idiomatic forms for 1/2 and 1/4.
+
+        ``1/2`` → "one half" (not "one secondth"); ``3/4`` → "three quarters"
+        (not "three fourths"). All other denominators use the ordinal-noun
+        rule: ``2/5`` → "two fifths", ``5/8`` → "five eighths".
+        Issue #584 ports savoirfairelinux/num2words#584.
+        """
+        if denominator == 0:
+            raise ZeroDivisionError("denominator must not be zero")
+        if denominator == 1 or numerator == 0:
+            return self.to_cardinal(numerator)
+        is_negative = (numerator < 0) ^ (denominator < 0)
+        abs_n = abs(int(numerator))
+        abs_d = abs(int(denominator))
+        # Idiomatic English forms for 1/2 and 1/4 — speakers say "half"
+        # and "quarter", not "secondth" or "fourth".
+        idiomatic = {
+            2: ("half", "halves"),
+            4: ("quarter", "quarters"),
+        }
+        if abs_d in idiomatic:
+            sing, plur = idiomatic[abs_d]
+            den_word = sing if abs_n == 1 else plur
+        else:
+            den_word = self.to_ordinal(abs_d)
+            if abs_n != 1:
+                den_word = den_word + "s"
+        sign = "minus " if is_negative else ""
+        return sign + self.to_cardinal(abs_n) + " " + den_word
+
     def to_year(self, val, suffix=None, longval=True):
         # Years are integers — refuse fractional input rather than emitting
         # float-precision noise like 'nineteen eighty point five nine nine

--- a/num2words2/lang_ES.py
+++ b/num2words2/lang_ES.py
@@ -467,6 +467,36 @@ class Num2Word_ES(Num2Word_EUR):
         self.verify_ordinal(value)
         return "%s%s" % (value, "º" if gender_stem == "o" else "ª")
 
+    def to_fraction(self, numerator, denominator):
+        """Spanish: 'medio/tercio/cuarto' for 2/3/4, ordinal-as-noun else.
+
+        Numerator 1 uses the apocopated 'un' rather than 'uno' (un medio,
+        un tercio, un quinto). Issue #584.
+        """
+        if denominator == 0:
+            raise ZeroDivisionError("denominator must not be zero")
+        if denominator == 1 or numerator == 0:
+            return self.to_cardinal(numerator)
+        is_negative = (numerator < 0) ^ (denominator < 0)
+        abs_n = abs(int(numerator))
+        abs_d = abs(int(denominator))
+        idiomatic = {
+            2: ("medio", "medios"),
+            3: ("tercio", "tercios"),
+            4: ("cuarto", "cuartos"),
+        }
+        if abs_d in idiomatic:
+            sing, plur = idiomatic[abs_d]
+            den_word = sing if abs_n == 1 else plur
+        else:
+            den_word = self.to_ordinal(abs_d)
+            if abs_n != 1 and not den_word.endswith("s"):
+                den_word = den_word + "s"
+        # Use 'un' rather than 'uno' for the apocopated form before nouns.
+        num_word = "un" if abs_n == 1 else self.to_cardinal(abs_n)
+        sign = "%s " % self.negword.strip() if is_negative else ""
+        return sign + num_word + " " + den_word
+
     def to_year(self, val, suffix=None, longval=True):
         """Convert number to year representation."""
         return self.to_cardinal(int(val))

--- a/num2words2/lang_FR.py
+++ b/num2words2/lang_FR.py
@@ -165,6 +165,35 @@ class Num2Word_FR(Num2Word_EUR):
         out += "er" if value == 1 else "me"
         return out
 
+    def to_fraction(self, numerator, denominator):
+        """French fractions: idiomatic 'demi/tiers/quart' for 2/3/4.
+
+        Other denominators use ordinal-as-noun with the regular -s plural
+        (un cinquième, deux cinquièmes). Issue #584.
+        """
+        if denominator == 0:
+            raise ZeroDivisionError("denominator must not be zero")
+        if denominator == 1 or numerator == 0:
+            return self.to_cardinal(numerator)
+        is_negative = (numerator < 0) ^ (denominator < 0)
+        abs_n = abs(int(numerator))
+        abs_d = abs(int(denominator))
+        # 'tiers' is invariant in plural, 'demi' and 'quart' take -s.
+        idiomatic = {
+            2: ("demi", "demis"),
+            3: ("tiers", "tiers"),
+            4: ("quart", "quarts"),
+        }
+        if abs_d in idiomatic:
+            sing, plur = idiomatic[abs_d]
+            den_word = sing if abs_n == 1 else plur
+        else:
+            den_word = self.to_ordinal(abs_d)
+            if abs_n != 1 and not den_word.endswith("s"):
+                den_word = den_word + "s"
+        sign = "%s " % self.negword.strip() if is_negative else ""
+        return sign + self.to_cardinal(abs_n) + " " + den_word
+
     def to_year(self, val, suffix=None, longval=True):
         """Convert number to year representation."""
         return self.to_cardinal(int(val))

--- a/num2words2/lang_IT.py
+++ b/num2words2/lang_IT.py
@@ -299,6 +299,36 @@ class Num2Word_IT(Num2Word_EUR):
         self.verify_ordinal(value)
         return str(int(value))
 
+    def to_fraction(self, numerator, denominator):
+        """Italian fractions: 'mezzo/terzo/quarto/quinto...' with -i plural.
+
+        Italian pluralizes the masculine noun ending -o → -i (un terzo /
+        due terzi), not -s. Also uses 'un' rather than 'uno' as the
+        numerator article. Issue #584.
+        """
+        if denominator == 0:
+            raise ZeroDivisionError("denominator must not be zero")
+        if denominator == 1 or numerator == 0:
+            return self.to_cardinal(numerator)
+        is_negative = (numerator < 0) ^ (denominator < 0)
+        abs_n = abs(int(numerator))
+        abs_d = abs(int(denominator))
+        idiomatic = {
+            2: ("mezzo", "mezzi"),
+        }
+        if abs_d in idiomatic:
+            sing, plur = idiomatic[abs_d]
+            den_word = sing if abs_n == 1 else plur
+        else:
+            den_word = self.to_ordinal(abs_d)
+            # Italian -o → -i for plural masculine nouns. The ordinal
+            # suffix is already -o for 1-10 and -esimo above.
+            if abs_n != 1 and den_word.endswith("o"):
+                den_word = den_word[:-1] + "i"
+        num_word = "un" if abs_n == 1 else self.to_cardinal(abs_n)
+        sign = "%s " % self.negword.strip() if is_negative else ""
+        return sign + num_word + " " + den_word
+
     def to_currency(
         self, val, currency="EUR", cents=True, separator=" e", adjective=False
     ):

--- a/num2words2/lang_PT.py
+++ b/num2words2/lang_PT.py
@@ -246,6 +246,33 @@ class Num2Word_PT(Num2Word_EUR):
         self.verify_ordinal(value)
         return "%sº" % (value)
 
+    def to_fraction(self, numerator, denominator):
+        """Portuguese fractions: 'meio/terço/quarto/quinto...' with -s plural.
+
+        Issue #584. Inherited by PT-BR.
+        """
+        if denominator == 0:
+            raise ZeroDivisionError("denominator must not be zero")
+        if denominator == 1 or numerator == 0:
+            return self.to_cardinal(numerator)
+        is_negative = (numerator < 0) ^ (denominator < 0)
+        abs_n = abs(int(numerator))
+        abs_d = abs(int(denominator))
+        idiomatic = {
+            2: ("meio", "meios"),
+            3: ("terço", "terços"),
+        }
+        if abs_d in idiomatic:
+            sing, plur = idiomatic[abs_d]
+            den_word = sing if abs_n == 1 else plur
+        else:
+            den_word = self.to_ordinal(abs_d)
+            if abs_n != 1 and not den_word.endswith("s"):
+                den_word = den_word + "s"
+        num_word = "um" if abs_n == 1 else self.to_cardinal(abs_n)
+        sign = "%s " % self.negword.strip() if is_negative else ""
+        return sign + num_word + " " + den_word
+
     def to_year(self, val, longval=True):
         # Before changing this function remember this is used by pt-BR
         # so act accordingly

--- a/tests/test_584_fractions.py
+++ b/tests/test_584_fractions.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+"""Issue savoirfairelinux/num2words#584 — fraction support.
+
+Strings of the form ``"<int>/<int>"`` are routed to the converter's
+``to_fraction(numerator, denominator)`` method. Idiomatic forms for
+common denominators are implemented per language; everything else falls
+back to ``<cardinal numerator> <ordinal denominator>[plural]``.
+"""
+from __future__ import unicode_literals
+
+import unittest
+
+from num2words2 import num2words
+
+
+class TestEnglishFractions(unittest.TestCase):
+
+    def test_unit_fractions(self):
+        self.assertEqual(num2words("1/2", lang="en"), "one half")
+        self.assertEqual(num2words("1/3", lang="en"), "one third")
+        self.assertEqual(num2words("1/4", lang="en"), "one quarter")
+        self.assertEqual(num2words("1/5", lang="en"), "one fifth")
+        self.assertEqual(num2words("1/8", lang="en"), "one eighth")
+
+    def test_plural_fractions(self):
+        self.assertEqual(num2words("2/3", lang="en"), "two thirds")
+        self.assertEqual(num2words("3/4", lang="en"), "three quarters")
+        self.assertEqual(num2words("5/8", lang="en"), "five eighths")
+        self.assertEqual(num2words("11/12", lang="en"), "eleven twelfths")
+
+    def test_improper_fractions(self):
+        self.assertEqual(num2words("5/3", lang="en"), "five thirds")
+        self.assertEqual(num2words("7/4", lang="en"), "seven quarters")
+
+    def test_zero_numerator(self):
+        self.assertEqual(num2words("0/3", lang="en"), "zero")
+        self.assertEqual(num2words("0/100", lang="en"), "zero")
+
+    def test_denominator_one(self):
+        self.assertEqual(num2words("1/1", lang="en"), "one")
+        self.assertEqual(num2words("5/1", lang="en"), "five")
+
+    def test_negative(self):
+        self.assertEqual(num2words("-1/3", lang="en"), "minus one third")
+        self.assertEqual(num2words("-3/4", lang="en"), "minus three quarters")
+        # Sign on denominator works the same.
+        self.assertEqual(num2words("1/-3", lang="en"), "minus one third")
+
+    def test_zero_denominator_raises(self):
+        with self.assertRaises(ZeroDivisionError):
+            num2words("1/0", lang="en")
+
+    def test_whitespace_tolerated(self):
+        self.assertEqual(num2words(" 1 / 3 ", lang="en"), "one third")
+
+    def test_explicit_to_fraction(self):
+        # Direct method call as well as dispatcher routing.
+        from num2words2 import CONVERTER_CLASSES
+        c = CONVERTER_CLASSES["en"]
+        self.assertEqual(c.to_fraction(2, 5), "two fifths")
+        self.assertEqual(c.to_fraction(1, 2), "one half")
+
+
+class TestRomanceLanguageFractions(unittest.TestCase):
+
+    def test_french_idiomatic(self):
+        self.assertEqual(num2words("1/2", lang="fr"), "un demi")
+        self.assertEqual(num2words("1/3", lang="fr"), "un tiers")
+        self.assertEqual(num2words("1/4", lang="fr"), "un quart")
+        self.assertEqual(num2words("2/3", lang="fr"), "deux tiers")
+        self.assertEqual(num2words("3/4", lang="fr"), "trois quarts")
+
+    def test_french_other(self):
+        self.assertEqual(num2words("5/8", lang="fr"), "cinq huitièmes")
+
+    def test_spanish_idiomatic(self):
+        self.assertEqual(num2words("1/2", lang="es"), "un medio")
+        self.assertEqual(num2words("1/3", lang="es"), "un tercio")
+        self.assertEqual(num2words("1/4", lang="es"), "un cuarto")
+        self.assertEqual(num2words("2/3", lang="es"), "dos tercios")
+
+    def test_italian_with_i_plural(self):
+        self.assertEqual(num2words("1/2", lang="it"), "un mezzo")
+        self.assertEqual(num2words("1/3", lang="it"), "un terzo")
+        self.assertEqual(num2words("2/3", lang="it"), "due terzi")
+        self.assertEqual(num2words("3/4", lang="it"), "tre quarti")
+
+    def test_portuguese_with_s_plural(self):
+        self.assertEqual(num2words("1/2", lang="pt"), "um meio")
+        self.assertEqual(num2words("1/3", lang="pt"), "um terço")
+        self.assertEqual(num2words("2/3", lang="pt"), "dois terços")
+        self.assertEqual(num2words("3/4", lang="pt"), "três quartos")
+
+    def test_pt_br_inherits(self):
+        self.assertEqual(num2words("1/3", lang="pt_BR"), "um terço")
+        self.assertEqual(num2words("3/4", lang="pt_BR"), "três quartos")
+
+
+class TestGermanFractions(unittest.TestCase):
+
+    def test_idiomatic(self):
+        self.assertEqual(num2words("1/2", lang="de"), "ein halb")
+        self.assertEqual(num2words("1/3", lang="de"), "ein Drittel")
+        self.assertEqual(num2words("1/4", lang="de"), "ein Viertel")
+        self.assertEqual(num2words("1/5", lang="de"), "ein Fünftel")
+        self.assertEqual(num2words("1/7", lang="de"), "ein Siebtel")
+        self.assertEqual(num2words("1/8", lang="de"), "ein Achtel")
+
+    def test_invariant_plural(self):
+        # German plural is invariant for these nouns: zwei Drittel, not
+        # zwei Drittels.
+        self.assertEqual(num2words("2/3", lang="de"), "zwei Drittel")
+        self.assertEqual(num2words("3/4", lang="de"), "drei Viertel")
+        self.assertEqual(num2words("5/8", lang="de"), "fünf Achtel")
+
+    def test_round_powers_drop_ein(self):
+        # The cardinal of 100 is 'einhundert' but the fraction noun is
+        # 'Hundertstel' (no leading 'ein').
+        self.assertEqual(num2words("1/100", lang="de"), "ein Hundertstel")
+        self.assertEqual(num2words("1/1000", lang="de"), "ein Tausendstel")
+
+    def test_above_twenty(self):
+        self.assertEqual(num2words("1/20", lang="de"), "ein Zwanzigstel")
+        self.assertEqual(num2words("1/13", lang="de"), "ein Dreizehntel")
+
+
+class TestFractionEdgeCases(unittest.TestCase):
+
+    def test_non_fraction_input_unchanged(self):
+        # Plain ints/floats still go through the cardinal/ordinal path.
+        self.assertEqual(num2words(42, lang="en"), "forty-two")
+        self.assertEqual(num2words(3.14, lang="en"), "three point one four")
+
+    def test_currency_path_unaffected(self):
+        # Don't accidentally route '1/100' as a fraction when the user
+        # really wants the currency conversion of integer 1 with currency
+        # set elsewhere — no false positive in the dispatcher.
+        out = num2words(1.50, lang="en", to="currency", currency="USD")
+        self.assertIn("dollar", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
[savoirfairelinux/num2words#584](https://github.com/savoirfairelinux/num2words/issues/584) — fraction support.

\`\`\`python
>>> num2words('1/3', lang='en')      # 'one third'
>>> num2words('1/2', lang='fr')      # 'un demi'
>>> num2words('2/3', lang='it')      # 'due terzi'
>>> num2words('3/4', lang='de')      # 'drei Viertel'
>>> num2words('1/100', lang='de')    # 'ein Hundertstel'
>>> num2words('-3/4', lang='en')     # 'minus three quarters'
\`\`\`

### Plumbing
- \`Num2Word_Base.to_fraction(num, denom)\` — default \`<cardinal numerator> <ordinal denominator>[s]\`
- Dispatcher detects \`'n/d'\` string pattern (whitespace tolerated) and routes to \`converter.to_fraction(int, int)\`
- \`'fraction'\` added to \`CONVERTES_TYPES\` for explicit \`to='fraction'\` calls
- \`ZeroDivisionError\` on \`'1/0'\`; \`'0/3'\` collapses to "zero"; \`'1/1'\` collapses to the cardinal

### Per-language idiomatic forms
| Language | Idiomatic | Plural rule |
|---|---|---|
| English | half/quarter | -s |
| French | demi/tiers/quart | -s (tiers invariant) |
| Spanish | medio/tercio/cuarto | -s, "un" for numerator 1 |
| Italian | mezzo | -o → -i |
| Portuguese (+ pt_BR) | meio/terço | -s |
| German | halb + Drittel/Viertel/Fünftel/... | invariant; "ein" not "eins" |

Other languages fall through to the base default. Anyone who wants their language properly supported can override \`to_fraction\` per the existing pattern.

### Test plan
- [x] \`tests/test_584_fractions.py\` — 21 cases: idiomatic + ordinal-fallback per language, signs, zero numerator, denominator 1, ZeroDivisionError, whitespace, currency-path-not-falsely-routed.
- [x] Full unittest suite passes (2945 tests)
- [x] flake8 + isort clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)