### PR TITLE
fix(en_aero): strict ICAO digit table + canonical en_Aero_ICAO key

### DIFF
--- a/num2words2/__init__.py
+++ b/num2words2/__init__.py
@@ -235,6 +235,15 @@ CONVERTER_CLASSES = {
     "dv": lang_DV.Num2Word_DV(),
     "el": lang_EL.Num2Word_EL(),
     "en": lang_EN.Num2Word_EN(),
+    # Aviation/ICAO digit-by-digit reading. The canonical key follows
+    # BCP 47 private-use shape (mapped via the dispatcher's hyphen-to-
+    # underscore normalisation): the BCP 47 tag 'en-x-aero-icao' resolves
+    # to the 'en_x_aero_icao' key below. The shorter 'en_Aero_ICAO' is
+    # the recommended in-code form. 'en_AERO' (and lowercase variants)
+    # are kept as aliases for back-compat with v1.0.14.
+    "en_Aero_ICAO": lang_EN_AERO.Num2Word_EN_AERO(),
+    "en_aero_icao": lang_EN_AERO.Num2Word_EN_AERO(),
+    "en_x_aero_icao": lang_EN_AERO.Num2Word_EN_AERO(),
     "en_AERO": lang_EN_AERO.Num2Word_EN_AERO(),
     "en_IN": lang_EN_IN.Num2Word_EN_IN(),
     "en_NE": lang_EN_NE.Num2Word_EN_NE(),

--- a/num2words2/lang_EN_AERO.py
+++ b/num2words2/lang_EN_AERO.py
@@ -27,14 +27,14 @@ from .lang_EN import Num2Word_EN
 # audio can mistake it for "nine", but "fife"/"niner" pair cleanly.
 _ICAO_DIGITS = {
     "0": "zero",
-    "1": "one",
-    "2": "two",
+    "1": "wun",
+    "2": "too",
     "3": "tree",
     "4": "fower",
     "5": "fife",
     "6": "six",
     "7": "seven",
-    "8": "eight",
+    "8": "ait",
     "9": "niner",
 }
 _ICAO_DECIMAL = "decimal"

--- a/tests/test_478_en_aero.py
+++ b/tests/test_478_en_aero.py
@@ -15,52 +15,68 @@ from num2words2 import num2words
 class TestEnAeroDigitByDigit(unittest.TestCase):
 
     def test_zero_through_nine(self):
+        # Strict ICAO Annex 10 vol II respellings (FAA / SKYbrary
+        # confirm the same set). 1/2/8 use the aggressive forms
+        # wun/too/ait, not the everyday English words.
         cases = {
             0: "zero",
-            1: "one",
-            2: "two",
+            1: "wun",
+            2: "too",
             3: "tree",
             4: "fower",
             5: "fife",
             6: "six",
             7: "seven",
-            8: "eight",
+            8: "ait",
             9: "niner",
         }
         for v, expected in cases.items():
-            self.assertEqual(num2words(v, lang="en_AERO"), expected)
+            self.assertEqual(num2words(v, lang="en_Aero_ICAO"), expected)
 
     def test_multi_digit(self):
         # The canonical example from the issue: 5739 → fife seven tree niner.
-        self.assertEqual(num2words(5739, lang="en_AERO"), "fife seven tree niner")
+        self.assertEqual(
+            num2words(5739, lang="en_Aero_ICAO"), "fife seven tree niner"
+        )
 
     def test_round_hundred(self):
         # Aviation reads round numbers digit-by-digit too.
-        self.assertEqual(num2words(100, lang="en_AERO"), "one zero zero")
-        self.assertEqual(num2words(1000, lang="en_AERO"), "one zero zero zero")
+        self.assertEqual(
+            num2words(100, lang="en_Aero_ICAO"), "wun zero zero"
+        )
+        self.assertEqual(
+            num2words(1000, lang="en_Aero_ICAO"), "wun zero zero zero"
+        )
 
     def test_year(self):
         # Years follow the same digit-by-digit rule.
         self.assertEqual(
-            num2words(1971, lang="en_AERO", to="year"), "one niner seven one"
+            num2words(1971, lang="en_Aero_ICAO", to="year"),
+            "wun niner seven wun",
         )
         self.assertEqual(
-            num2words(2026, lang="en_AERO", to="year"), "two zero two six"
+            num2words(2026, lang="en_Aero_ICAO", to="year"),
+            "too zero too six",
         )
 
     def test_decimal_point(self):
         # The decimal mark is "decimal" in ICAO usage.
         self.assertEqual(
-            num2words(127.5, lang="en_AERO"), "one two seven decimal fife"
+            num2words(127.5, lang="en_Aero_ICAO"),
+            "wun too seven decimal fife",
         )
         self.assertEqual(
-            num2words(0.99, lang="en_AERO"), "zero decimal niner niner"
+            num2words(0.99, lang="en_Aero_ICAO"),
+            "zero decimal niner niner",
         )
 
     def test_negative(self):
-        self.assertEqual(num2words(-42, lang="en_AERO"), "minus fower two")
         self.assertEqual(
-            num2words(-1.5, lang="en_AERO"), "minus one decimal fife"
+            num2words(-42, lang="en_Aero_ICAO"), "minus fower too"
+        )
+        self.assertEqual(
+            num2words(-1.5, lang="en_Aero_ICAO"),
+            "minus wun decimal fife",
         )
 
 
@@ -68,12 +84,13 @@ class TestEnAeroStringInput(unittest.TestCase):
 
     def test_string_int(self):
         self.assertEqual(
-            num2words("5739", lang="en_AERO"), "fife seven tree niner"
+            num2words("5739", lang="en_Aero_ICAO"), "fife seven tree niner"
         )
 
     def test_string_float(self):
         self.assertEqual(
-            num2words("127.5", lang="en_AERO"), "one two seven decimal fife"
+            num2words("127.5", lang="en_Aero_ICAO"),
+            "wun too seven decimal fife",
         )
 
     def test_explicit_method_call_strips_separators(self):
@@ -82,26 +99,42 @@ class TestEnAeroStringInput(unittest.TestCase):
         # num2words_sentence). Calling to_cardinal directly handles them
         # via _digits_of. Document that here as the supported path.
         from num2words2 import CONVERTER_CLASSES
-        c = CONVERTER_CLASSES["en_AERO"]
-        self.assertEqual(c.to_cardinal("12,345"), "one two tree fower fife")
-        self.assertEqual(c.to_cardinal("12_345"), "one two tree fower fife")
+        c = CONVERTER_CLASSES["en_Aero_ICAO"]
+        self.assertEqual(c.to_cardinal("12,345"), "wun too tree fower fife")
+        self.assertEqual(c.to_cardinal("12_345"), "wun too tree fower fife")
 
 
 class TestEnAeroLookup(unittest.TestCase):
+    """The canonical key is ``en_Aero_ICAO``. Aliases keep older
+    callers working: ``en_aero_icao``, ``en-x-aero-icao`` (BCP 47
+    private-use form), and the v1.0.14 alias ``en_AERO``."""
 
-    def test_underscore_lower(self):
+    def test_canonical_key(self):
         self.assertEqual(
-            num2words(5739, lang="en_aero"), "fife seven tree niner"
+            num2words(5739, lang="en_Aero_ICAO"), "fife seven tree niner"
         )
 
-    def test_dash_upper(self):
+    def test_lowercase_alias(self):
+        self.assertEqual(
+            num2words(5739, lang="en_aero_icao"), "fife seven tree niner"
+        )
+
+    def test_bcp47_private_use(self):
+        # 'en-x-aero-icao' — BCP 47 private-use subtag form.
+        self.assertEqual(
+            num2words(5739, lang="en-x-aero-icao"), "fife seven tree niner"
+        )
+
+    def test_v1014_back_compat_alias(self):
+        # The v1.0.14 keys still resolve to the same converter.
+        self.assertEqual(
+            num2words(5739, lang="en_AERO"), "fife seven tree niner"
+        )
         self.assertEqual(
             num2words(5739, lang="en-AERO"), "fife seven tree niner"
         )
-
-    def test_dash_lower(self):
         self.assertEqual(
-            num2words(5739, lang="en-aero"), "fife seven tree niner"
+            num2words(5739, lang="en_aero"), "fife seven tree niner"
         )
 
 
@@ -110,8 +143,8 @@ class TestEnAeroFractionsRoute(unittest.TestCase):
     inherits to_fraction from Num2Word_EN."""
 
     def test_fraction_inherits_english(self):
-        self.assertEqual(num2words("1/3", lang="en_AERO"), "one third")
-        self.assertEqual(num2words("1/2", lang="en_AERO"), "one half")
+        self.assertEqual(num2words("1/3", lang="en_Aero_ICAO"), "one third")
+        self.assertEqual(num2words("1/2", lang="en_Aero_ICAO"), "one half")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
v1.0.14 shipped \`en_AERO\` with the *common* subset of ICAO respellings (3→tree, 4→fower, 5→fife, 7→seven, 9→niner) and left 1/2/8 as their everyday English words.

The reviewer pointed out — citing FAA phraseology, SKYbrary/EUROCONTROL, and ICAO Annex 10 vol II — that the strict table also respells **1 → wun, 2 → too, 8 → ait**. Use those so the output matches what pilots/ATC actually say.

\`\`\`python
>>> num2words(5739, lang='en_Aero_ICAO')
'fife seven tree niner'
>>> num2words(127.5, lang='en_Aero_ICAO')
'wun too seven decimal fife'
>>> num2words(8, lang='en_Aero_ICAO')
'ait'
\`\`\`

## Locale key
- **Canonical:** \`en_Aero_ICAO\` (per the reviewer's recommendation; matches BCP 47 private-use shape).
- Aliases: \`en_aero_icao\`, \`en_x_aero_icao\` (so the BCP 47 form \`en-x-aero-icao\` resolves through the existing hyphen→underscore normalisation).
- v1.0.14 \`en_AERO\` and lowercase variants remain as back-compat aliases.

## Test plan
- [x] 14 cases in \`tests/test_478_en_aero.py\` updated for the strict digit table and the new canonical key.
- [x] Full unittest suite passes (2959 tests)
- [x] flake8 + isort clean

## Sources cited by reviewer
- ICAO Annex 10 vol II
- FAA AIM 4-2-9 / faa.gov chap11_section_1
- SKYbrary phonetic alphabet
- RFC 5646 (BCP 47)

🤖 Generated with [Claude Code](https://claude.com/claude-code)