### PR TITLE
feat(en_aero): aviation context phraseology (altitude, FL, heading, squawk, runway, freq)

### DIFF
--- a/num2words2/lang_EN_AERO.py
+++ b/num2words2/lang_EN_AERO.py
@@ -118,3 +118,124 @@ class Num2Word_EN_AERO(Num2Word_EN):
 
     def to_cheque(self, *args, **kwargs):
         return self._english.to_cheque(*args, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Aviation-specific phraseology. These follow FAA AIM 4-2-9 and
+    # ICAO Annex 10 vol II conventions. Each method has its own rules
+    # for which numerals are read as composite words vs digit-by-digit.
+    # ------------------------------------------------------------------
+
+    def _icao_digit(self, n):
+        """Return the ICAO respelling of a single decimal digit."""
+        return _ICAO_DIGITS[str(int(n))]
+
+    def _icao_digits(self, s):
+        """Render every digit character of ``s`` as ICAO words."""
+        return " ".join(self._icao_digit(ch) for ch in str(s) if ch.isdigit())
+
+    def to_altitude(self, value, unit="feet"):
+        """FAA / ICAO altitude phraseology.
+
+        Below 10 000: "<single ICAO digit> thousand[, <hundreds> hundred]"
+                      — e.g. 5500 → "fife thousand fife hundred"
+        At 10 000 and above: thousands portion is read digit-by-digit
+                      — e.g. 12 500 → "wun too thousand fife hundred"
+                            25 000 → "too fife thousand"
+        Trailing unit is appended (default "feet"). Source: FAA AIM 4-2-9.
+        """
+        v = int(value)
+        if v < 0:
+            raise ValueError("altitude must be non-negative")
+        thousands = v // 1000
+        hundreds = (v % 1000) // 100
+        leftover = v % 100
+        parts = []
+        if thousands > 0:
+            if thousands < 10:
+                parts.append(self._icao_digit(thousands))
+            else:
+                parts.append(self._icao_digits(thousands))
+            parts.append("thousand")
+        if hundreds > 0:
+            parts.append(self._icao_digit(hundreds))
+            parts.append("hundred")
+        if leftover > 0:
+            # Sub-hundred altitudes are rare but speakable digit-by-digit.
+            parts.append(self._icao_digits("%02d" % leftover))
+        if v == 0:
+            parts.append("zero")
+        if unit:
+            parts.append(unit)
+        return " ".join(parts)
+
+    def to_flight_level(self, value):
+        """Flight level: ``flight level <three-digit-by-digit>``.
+
+        FL230 → "flight level too tree zero". The numeric input is
+        always rendered as a 3-digit, zero-padded sequence.
+        """
+        v = int(value)
+        if not 0 <= v <= 999:
+            raise ValueError("flight level must be a 3-digit code (0-999)")
+        return "flight level %s" % self._icao_digits("%03d" % v)
+
+    def to_heading(self, value):
+        """Heading: ``heading <three-digit-by-digit>``.
+
+        Magnetic headings are always read as three digits including
+        leading zeros: 30 → "heading zero tree zero", 360 → "heading
+        tree six zero". Values outside 0-360 are taken modulo 360.
+        """
+        v = int(value) % 360 or 360
+        return "heading %s" % self._icao_digits("%03d" % v)
+
+    def to_squawk(self, value):
+        """Transponder code: ``squawk <four-digit-by-digit>``.
+
+        Codes are 4-digit octal (each digit 0-7); 7700 → "squawk seven
+        seven zero zero". The input is zero-padded to four digits.
+        """
+        v = int(value)
+        if not 0 <= v <= 7777:
+            raise ValueError("squawk code must be 4 octal digits (0-7777)")
+        return "squawk %s" % self._icao_digits("%04d" % v)
+
+    def to_runway(self, value):
+        """Runway designator: ``runway <digits> [left|right|center]``.
+
+        Accepts integer ('27', '9') or string ('27R', '09L', '36C').
+        Suffixes L/R/C (case-insensitive) are spoken as left/right/center.
+        Magnetic-bearing digits are always read digit-by-digit.
+        """
+        s = str(value).strip().upper()
+        suffix_map = {"L": "left", "R": "right", "C": "center"}
+        suffix = ""
+        if s and s[-1] in suffix_map:
+            suffix = suffix_map[s[-1]]
+            s = s[:-1]
+        # Strip non-digit characters that may remain (e.g. whitespace).
+        digits = "".join(ch for ch in s if ch.isdigit())
+        if not digits:
+            raise ValueError("runway designator must contain digits")
+        parts = ["runway", self._icao_digits(digits)]
+        if suffix:
+            parts.append(suffix)
+        return " ".join(parts)
+
+    def to_frequency(self, value):
+        """Radio frequency: ``<digits> decimal <digits>``.
+
+        Common in voice-radio comms — 121.5 → "wun too wun decimal fife".
+        Trailing zeros after the decimal are preserved as digits.
+        """
+        s = str(value).strip()
+        if "." in s:
+            int_part, frac_part = s.split(".", 1)
+        else:
+            int_part, frac_part = s, ""
+        if not int_part:
+            int_part = "0"
+        out = self._icao_digits(int_part)
+        if frac_part:
+            out += " decimal " + self._icao_digits(frac_part)
+        return out

--- a/tests/test_478_en_aero.py
+++ b/tests/test_478_en_aero.py
@@ -147,5 +147,138 @@ class TestEnAeroFractionsRoute(unittest.TestCase):
         self.assertEqual(num2words("1/2", lang="en_Aero_ICAO"), "one half")
 
 
+class TestEnAeroAviationPhraseology(unittest.TestCase):
+    """Aviation-specific reading conventions for altitude / flight level
+    / heading / squawk / runway / frequency. Each follows FAA AIM 4-2-9
+    and the matching ICAO Annex 10 vol II rule.
+
+    These methods are aviation-only and live on Num2Word_EN_AERO; users
+    call them via the converter instance:
+
+        from num2words2 import CONVERTER_CLASSES
+        aero = CONVERTER_CLASSES['en_Aero_ICAO']
+        aero.to_altitude(5500)   # "fife thousand fife hundred feet"
+    """
+
+    def setUp(self):
+        from num2words2 import CONVERTER_CLASSES
+        self.aero = CONVERTER_CLASSES["en_Aero_ICAO"]
+
+    # ---- altitude ----
+    def test_altitude_thousands_under_10k(self):
+        self.assertEqual(
+            self.aero.to_altitude(5500),
+            "fife thousand fife hundred feet",
+        )
+        self.assertEqual(
+            self.aero.to_altitude(1000),
+            "wun thousand feet",
+        )
+        self.assertEqual(
+            self.aero.to_altitude(9900),
+            "niner thousand niner hundred feet",
+        )
+
+    def test_altitude_at_or_above_10k_digit_by_digit(self):
+        # Per FAA AIM 4-2-9, ≥10 000 ft uses digit-by-digit thousands.
+        self.assertEqual(
+            self.aero.to_altitude(10000),
+            "wun zero thousand feet",
+        )
+        self.assertEqual(
+            self.aero.to_altitude(12500),
+            "wun too thousand fife hundred feet",
+        )
+        self.assertEqual(
+            self.aero.to_altitude(25000),
+            "too fife thousand feet",
+        )
+
+    def test_altitude_unit_override(self):
+        self.assertEqual(
+            self.aero.to_altitude(3000, unit="meters"),
+            "tree thousand meters",
+        )
+
+    def test_altitude_negative_raises(self):
+        with self.assertRaises(ValueError):
+            self.aero.to_altitude(-100)
+
+    # ---- flight level ----
+    def test_flight_level(self):
+        self.assertEqual(self.aero.to_flight_level(230), "flight level too tree zero")
+        self.assertEqual(self.aero.to_flight_level(360), "flight level tree six zero")
+        self.assertEqual(self.aero.to_flight_level(50), "flight level zero fife zero")
+
+    def test_flight_level_out_of_range(self):
+        with self.assertRaises(ValueError):
+            self.aero.to_flight_level(1000)
+
+    # ---- heading ----
+    def test_heading_three_digits(self):
+        self.assertEqual(self.aero.to_heading(360), "heading tree six zero")
+        self.assertEqual(self.aero.to_heading(30), "heading zero tree zero")
+        self.assertEqual(self.aero.to_heading(180), "heading wun ait zero")
+
+    def test_heading_zero_maps_to_360(self):
+        # In aviation, 360 (or 000) is north. Treat 0 as 360.
+        self.assertEqual(self.aero.to_heading(0), "heading tree six zero")
+
+    # ---- squawk ----
+    def test_squawk_codes(self):
+        # Common codes: 7700 emergency, 7600 lost-comms, 7500 hijack,
+        # 1200 VFR (US).
+        self.assertEqual(self.aero.to_squawk(7700), "squawk seven seven zero zero")
+        self.assertEqual(self.aero.to_squawk(7600), "squawk seven six zero zero")
+        self.assertEqual(self.aero.to_squawk(7500), "squawk seven fife zero zero")
+        self.assertEqual(self.aero.to_squawk(1200), "squawk wun too zero zero")
+        self.assertEqual(self.aero.to_squawk(0), "squawk zero zero zero zero")
+
+    def test_squawk_out_of_range(self):
+        with self.assertRaises(ValueError):
+            self.aero.to_squawk(8888)
+
+    # ---- runway ----
+    def test_runway_with_suffix(self):
+        self.assertEqual(self.aero.to_runway("27R"), "runway too seven right")
+        self.assertEqual(self.aero.to_runway("09L"), "runway zero niner left")
+        self.assertEqual(self.aero.to_runway("36C"), "runway tree six center")
+
+    def test_runway_no_suffix(self):
+        self.assertEqual(self.aero.to_runway("14"), "runway wun fower")
+        self.assertEqual(self.aero.to_runway("5"), "runway fife")
+
+    def test_runway_int_input(self):
+        self.assertEqual(self.aero.to_runway(27), "runway too seven")
+
+    def test_runway_lowercase_suffix(self):
+        self.assertEqual(self.aero.to_runway("27r"), "runway too seven right")
+
+    # ---- frequency ----
+    def test_frequency_with_decimal(self):
+        # Common ATC freqs: 121.5 = guard; 118.x range = tower.
+        self.assertEqual(
+            self.aero.to_frequency(121.5),
+            "wun too wun decimal fife",
+        )
+        self.assertEqual(
+            self.aero.to_frequency(118.025),
+            "wun wun ait decimal zero too fife",
+        )
+
+    def test_frequency_string_preserves_trailing_zero(self):
+        # Strings keep trailing zeros that float literals lose.
+        self.assertEqual(
+            self.aero.to_frequency("121.50"),
+            "wun too wun decimal fife zero",
+        )
+
+    def test_frequency_integer(self):
+        self.assertEqual(
+            self.aero.to_frequency(122),
+            "wun too too",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Extends \`en_Aero_ICAO\` with the per-context reading rules called out in the upstream-issue follow-up — addressing the reviewer's point that *"not every aeronautical number is always read the same way"* (altitudes, flight levels, runways, squawk codes, frequencies all have specific FAA/ICAO conventions).

\`\`\`python
>>> from num2words2 import CONVERTER_CLASSES
>>> aero = CONVERTER_CLASSES['en_Aero_ICAO']

>>> aero.to_altitude(5500)        # 'fife thousand fife hundred feet'
>>> aero.to_altitude(12500)       # 'wun too thousand fife hundred feet'
>>> aero.to_altitude(25000)       # 'too fife thousand feet'

>>> aero.to_flight_level(230)     # 'flight level too tree zero'

>>> aero.to_heading(360)          # 'heading tree six zero'
>>> aero.to_heading(30)           # 'heading zero tree zero'

>>> aero.to_squawk(7700)          # 'squawk seven seven zero zero'
>>> aero.to_squawk(1200)          # 'squawk wun too zero zero'

>>> aero.to_runway('27R')         # 'runway too seven right'
>>> aero.to_runway('09L')         # 'runway zero niner left'
>>> aero.to_runway(14)            # 'runway wun fower'

>>> aero.to_frequency(121.5)      # 'wun too wun decimal fife'
>>> aero.to_frequency(118.025)    # 'wun wun ait decimal zero too fife'
\`\`\`

## Why direct method calls (not \`to=\` dispatcher mode)
The aviation methods are AERO-only and three of them (altitude with unit override, runway with string-suffix input like \`'27R'\`, squawk with octal-range validation) don't cleanly fit the dispatcher's "single numeric input → single string output" pattern. Calling \`aero.to_X(...)\` directly keeps the API honest about the aviation-context-only nature and avoids polluting CONVERTES_TYPES with modes that other languages can't sensibly implement.

## Conventions implemented
| Method | FAA / ICAO rule |
|---|---|
| \`to_altitude\` | < 10 000 ft → thousands as single ICAO digit + \`thousand\`; ≥ 10 000 ft → thousands digit-by-digit. Hundreds always single digit + \`hundred\`. |
| \`to_flight_level\` | \`flight level\` + 3-digit zero-padded sequence. |
| \`to_heading\` | \`heading\` + 3-digit zero-padded sequence; \`0\` maps to \`360\`. |
| \`to_squawk\` | \`squawk\` + 4-digit zero-padded sequence; validates 0-7777 (octal). |
| \`to_runway\` | Magnetic bearing digits + optional \`left\`/\`right\`/\`center\` from L/R/C suffix. |
| \`to_frequency\` | Digits + \`decimal\` + digits. Strings preserve trailing zeros. |

## Test plan
- [x] 17 new cases in \`tests/test_478_en_aero.py\` covering each method, including range validation, FAA 10 000 ft altitude switch, suffix parsing, lowercase/uppercase suffixes, integer vs string runway input.
- [x] Existing 14 AERO tests still pass.
- [x] Full unittest suite passes (2976 tests).
- [x] flake8 + isort clean.

## Sources cited by reviewer
- ICAO Annex 10 vol II
- FAA AIM 4-2-9 / faa.gov chap11_section_1
- SKYbrary phraseology

🤖 Generated with [Claude Code](https://claude.com/claude-code)