### PR TITLE
feat(en_aero): service-specific aviation profiles (FAA, USN, US_Army, NATO)

### DIFF
--- a/num2words2/__init__.py
+++ b/num2words2/__init__.py
@@ -245,6 +245,19 @@ CONVERTER_CLASSES = {
     "en_aero_icao": lang_EN_AERO.Num2Word_EN_AERO(),
     "en_x_aero_icao": lang_EN_AERO.Num2Word_EN_AERO(),
     "en_AERO": lang_EN_AERO.Num2Word_EN_AERO(),
+    # Service-specific aviation profiles (per the upstream issue's request
+    # to "implement the different variations depending on ICAO, FAA,
+    # US Navy, US Army"). Modern services have converged on the ICAO
+    # digit table for joint operations, so today these all produce the
+    # same output as the ICAO profile — they're separate entry points
+    # so callers can document *which* standard they're targeting and so
+    # historical/tactical variants can diverge later without breaking
+    # callers. Issue savoirfairelinux/num2words#478.
+    "en_Aero_FAA": lang_EN_AERO.Num2Word_EN_AERO_FAA(),
+    "en_Aero_USN": lang_EN_AERO.Num2Word_EN_AERO_USN(),
+    "en_Aero_US_Navy": lang_EN_AERO.Num2Word_EN_AERO_USN(),
+    "en_Aero_US_Army": lang_EN_AERO.Num2Word_EN_AERO_US_Army(),
+    "en_Aero_NATO": lang_EN_AERO.Num2Word_EN_AERO_NATO(),
     "en_IN": lang_EN_IN.Num2Word_EN_IN(),
     "en_NE": lang_EN_NE.Num2Word_EN_NE(),
     "en_NG": lang_EN_NG.Num2Word_EN_NG(),

--- a/num2words2/lang_EN_AERO.py
+++ b/num2words2/lang_EN_AERO.py
@@ -22,9 +22,19 @@ from decimal import Decimal
 
 from .lang_EN import Num2Word_EN
 
-# ICAO standard digit pronunciations. The respellings are chosen to be
+# Per-profile digit pronunciations. The respellings are chosen to be
 # distinct under heavy radio static; speakers who hear "five" in noisy
 # audio can mistake it for "nine", but "fife"/"niner" pair cleanly.
+#
+# Modern services (ICAO / FAA / US Navy / US Army / NATO) have all
+# converged on the same number-pronunciation table — they all defer to
+# ICAO Annex 10 vol II for joint operations. Historical variants
+# (WW2-era US Army/Navy, RAF, ITU/IMO) used different respellings; the
+# scaffolding below makes it easy to add those as additional profiles
+# without rewriting the engine. Today the four profiles below are
+# intentionally identical — they exist as named entry points so users
+# can document *which* standard they're targeting.
+
 _ICAO_DIGITS = {
     "0": "zero",
     "1": "wun",
@@ -40,21 +50,50 @@ _ICAO_DIGITS = {
 _ICAO_DECIMAL = "decimal"
 _ICAO_MINUS = "minus"
 
+# Each profile is (digits-table, decimal-word, minus-word). Adding a
+# new profile is a one-line table addition.
+_PROFILES = {
+    "ICAO": (_ICAO_DIGITS, _ICAO_DECIMAL, _ICAO_MINUS),
+    "FAA": (_ICAO_DIGITS, _ICAO_DECIMAL, _ICAO_MINUS),
+    "USN": (_ICAO_DIGITS, _ICAO_DECIMAL, _ICAO_MINUS),
+    "US_ARMY": (_ICAO_DIGITS, _ICAO_DECIMAL, _ICAO_MINUS),
+    "NATO": (_ICAO_DIGITS, _ICAO_DECIMAL, _ICAO_MINUS),
+}
+
 
 class Num2Word_EN_AERO(Num2Word_EN):
-    """Digit-by-digit ICAO reading of any numeric input.
+    """Digit-by-digit aviation/military reading of any numeric input.
 
     The AERO variant only standardises cardinal/year reading. Higher-level
     modes that depend on cardinals internally (ordinals, fractions,
     currency) delegate to a sibling ``Num2Word_EN`` instance so they
     don't accidentally pick up the digit-by-digit cardinal form (which
     would turn "third" into "treeth" via vowel-substitution chaining).
+
+    The class accepts a ``profile=`` constructor argument selecting one
+    of the published standards. Today they all use the same digit table
+    (modern services have converged on ICAO); the parameter exists so
+    historical or service-specific variants can be added without
+    breaking back-compat.
     """
 
-    def __init__(self):
+    PROFILE = "ICAO"  # subclasses override
+
+    def __init__(self, profile=None):
         super(Num2Word_EN_AERO, self).__init__()
         # Hold a plain-English helper for modes ICAO doesn't standardise.
         self._english = Num2Word_EN()
+        chosen = profile or self.PROFILE
+        if chosen not in _PROFILES:
+            raise ValueError(
+                "Unknown aviation profile %r; valid: %s"
+                % (chosen, sorted(_PROFILES))
+            )
+        digits, decimal_word, minus_word = _PROFILES[chosen]
+        self._digit_table = digits
+        self._decimal_word = decimal_word
+        self._minus_word = minus_word
+        self.profile = chosen
 
     def _digits_of(self, value):
         # Normalise input to (sign, integer-part-string, fractional-part-string).
@@ -82,15 +121,15 @@ class Num2Word_EN_AERO(Num2Word_EN):
         is_negative, int_part, frac_part = self._digits_of(value)
         words = []
         if is_negative:
-            words.append(_ICAO_MINUS)
+            words.append(self._minus_word)
         for ch in int_part:
             if ch.isdigit():
-                words.append(_ICAO_DIGITS[ch])
+                words.append(self._digit_table[ch])
         if frac_part:
-            words.append(_ICAO_DECIMAL)
+            words.append(self._decimal_word)
             for ch in frac_part:
                 if ch.isdigit():
-                    words.append(_ICAO_DIGITS[ch])
+                    words.append(self._digit_table[ch])
         return " ".join(words)
 
     def to_year(self, value, **kwargs):
@@ -126,11 +165,11 @@ class Num2Word_EN_AERO(Num2Word_EN):
     # ------------------------------------------------------------------
 
     def _icao_digit(self, n):
-        """Return the ICAO respelling of a single decimal digit."""
-        return _ICAO_DIGITS[str(int(n))]
+        """Return the active profile's respelling of a single decimal digit."""
+        return self._digit_table[str(int(n))]
 
     def _icao_digits(self, s):
-        """Render every digit character of ``s`` as ICAO words."""
+        """Render every digit character of ``s`` as profile words."""
         return " ".join(self._icao_digit(ch) for ch in str(s) if ch.isdigit())
 
     def to_altitude(self, value, unit="feet"):
@@ -239,3 +278,33 @@ class Num2Word_EN_AERO(Num2Word_EN):
         if frac_part:
             out += " decimal " + self._icao_digits(frac_part)
         return out
+
+
+# ---------------------------------------------------------------------
+# Service-specific profile subclasses. Modern services have converged
+# on the ICAO digit table for joint operations, so these all produce
+# the same output today as the ICAO base — they exist as named entry
+# points so callers can document *which* standard they're targeting,
+# and so historical/tactical variants can diverge later without
+# breaking back-compat. Issue savoirfairelinux/num2words#478.
+# ---------------------------------------------------------------------
+
+
+class Num2Word_EN_AERO_FAA(Num2Word_EN_AERO):
+    """FAA AIM 4-2-9 phraseology — adopts ICAO digit pronunciation."""
+    PROFILE = "FAA"
+
+
+class Num2Word_EN_AERO_USN(Num2Word_EN_AERO):
+    """US Navy / Coast Guard — adopts ICAO digit pronunciation."""
+    PROFILE = "USN"
+
+
+class Num2Word_EN_AERO_US_Army(Num2Word_EN_AERO):
+    """US Army — adopts ICAO digit pronunciation for joint operations."""
+    PROFILE = "US_ARMY"
+
+
+class Num2Word_EN_AERO_NATO(Num2Word_EN_AERO):
+    """NATO STANAG 1059 — defers to ICAO for digit pronunciation."""
+    PROFILE = "NATO"

--- a/tests/test_478_en_aero.py
+++ b/tests/test_478_en_aero.py
@@ -280,5 +280,71 @@ class TestEnAeroAviationPhraseology(unittest.TestCase):
         )
 
 
+class TestEnAeroServiceProfiles(unittest.TestCase):
+    """Service-specific aviation profiles. Modern services (ICAO, FAA,
+    US Navy, US Army, NATO) have converged on the same ICAO digit
+    table for joint operations, so the variants currently produce
+    identical output. They're separate locale keys + classes so callers
+    can name *which* standard they're targeting, and so future divergent
+    profiles (historical respellings, ITU/IMO maritime variants, etc.)
+    can be added without breaking back-compat. Per the request on
+    savoirfairelinux/num2words#478.
+    """
+
+    REGISTERED = [
+        "en_Aero_ICAO",
+        "en_Aero_FAA",
+        "en_Aero_USN",
+        "en_Aero_US_Navy",
+        "en_Aero_US_Army",
+        "en_Aero_NATO",
+    ]
+
+    def test_all_variants_registered(self):
+        from num2words2 import CONVERTER_CLASSES
+        for code in self.REGISTERED:
+            self.assertIn(code, CONVERTER_CLASSES)
+
+    def test_all_variants_produce_icao_today(self):
+        # Modern services all defer to ICAO. Output should match exactly
+        # for an arbitrary input.
+        outputs = {
+            code: num2words(5739, lang=code) for code in self.REGISTERED
+        }
+        unique = set(outputs.values())
+        self.assertEqual(unique, {"fife seven tree niner"}, outputs)
+
+    def test_profile_attribute(self):
+        from num2words2 import CONVERTER_CLASSES
+        expected = {
+            "en_Aero_ICAO": "ICAO",
+            "en_Aero_FAA": "FAA",
+            "en_Aero_USN": "USN",
+            "en_Aero_US_Navy": "USN",
+            "en_Aero_US_Army": "US_ARMY",
+            "en_Aero_NATO": "NATO",
+        }
+        for code, profile in expected.items():
+            self.assertEqual(CONVERTER_CLASSES[code].profile, profile)
+
+    def test_aviation_methods_available_on_each_variant(self):
+        from num2words2 import CONVERTER_CLASSES
+        for code in self.REGISTERED:
+            c = CONVERTER_CLASSES[code]
+            self.assertEqual(c.to_altitude(5500), "fife thousand fife hundred feet")
+            self.assertEqual(c.to_squawk(7700), "squawk seven seven zero zero")
+
+    def test_explicit_profile_constructor_arg(self):
+        from num2words2.lang_EN_AERO import Num2Word_EN_AERO
+        c = Num2Word_EN_AERO(profile="FAA")
+        self.assertEqual(c.profile, "FAA")
+        self.assertEqual(c.to_cardinal(5739), "fife seven tree niner")
+
+    def test_unknown_profile_raises(self):
+        from num2words2.lang_EN_AERO import Num2Word_EN_AERO
+        with self.assertRaises(ValueError):
+            Num2Word_EN_AERO(profile="Klingon")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Closes the last bullet of [savoirfairelinux/num2words#478](https://github.com/savoirfairelinux/num2words/issues/478): *"different variations depending on ICAO, FAA, US Navy, US Army, and other respellings"*.

\`\`\`python
>>> num2words(5739, lang='en_Aero_FAA')       # 'fife seven tree niner'
>>> num2words(5739, lang='en_Aero_USN')       # 'fife seven tree niner'
>>> num2words(5739, lang='en_Aero_US_Navy')   # 'fife seven tree niner'
>>> num2words(5739, lang='en_Aero_US_Army')   # 'fife seven tree niner'
>>> num2words(5739, lang='en_Aero_NATO')      # 'fife seven tree niner'

>>> from num2words2.lang_EN_AERO import Num2Word_EN_AERO
>>> Num2Word_EN_AERO(profile='FAA').to_cardinal(5739)
'fife seven tree niner'
\`\`\`

## Honest scope note
Modern services have all converged on the ICAO digit table for joint operations (FAA AIM 4-2-9 cites ICAO; STANAG 1059 defers to ICAO; US military adopted ICAO post-1956). So today **all five profiles produce identical output**.

They exist as separate named entry points for two reasons:

1. **Self-documenting calls.** Code can say "we use FAA phraseology" even when the output matches ICAO byte-for-byte.
2. **Future divergence.** Historical WW2-era US Army/Navy respellings, ITU/IMO maritime variants, and tactical deviations can be added by populating their \`_PROFILES\` tuple without breaking back-compat.

## Implementation
- \`_PROFILES\` dict keyed by profile name maps to \`(digits, decimal_word, minus_word)\` tuples.
- \`Num2Word_EN_AERO\` accepts a \`profile=\` constructor arg, validates against \`_PROFILES\`, ValueError on unknown.
- Four sibling classes (\`Num2Word_EN_AERO_FAA\` / \`_USN\` / \`_US_Army\` / \`_NATO\`) inherit and set \`PROFILE\` class constant.
- Six locale keys registered.

### Bug fix bundled
An earlier draft placed the subclasses inside the parent class scope by accident, which silently ended \`Num2Word_EN_AERO\` before its methods were defined and broke \`to_cardinal\`/\`to_altitude\`/etc. (caught by the smoke test where ICAO suddenly produced plain-English output instead of digit-by-digit). Subclasses now live at module level after the parent class body.

## Test plan
- [x] 6 new cases (registration, profile attribute, output parity, aviation-method availability, programmatic \`profile=\`, unknown-profile ValueError)
- [x] All 37 \`tests.test_478_en_aero\` cases pass
- [x] Full unittest suite passes (2982 tests)
- [x] flake8 + isort clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)