### PR TITLE
ci: auto-purge camo cache on release so README badges refresh

### DIFF
--- a/.github/workflows/refresh-readme-badges.yml
+++ b/.github/workflows/refresh-readme-badges.yml
@@ -1,0 +1,76 @@
+name: Refresh README badges
+
+# GitHub serves images embedded in the README via the Camo image proxy
+# (camo.githubusercontent.com). Camo aggressively caches each upstream
+# image URL — typical TTL is ~24h — so when shields.io or coveralls.io
+# update, repository visitors keep seeing the stale badge until either
+# Camo refreshes on its own or someone PURGEs the cached entry.
+#
+# This workflow PURGEs every Camo URL referenced from the rendered
+# README so the new release/coverage value shows up immediately. Runs:
+#  * on every push to the default branch (e.g. when README changes)
+#  * after every v* tag (so PyPI/AUR version badges flip on release)
+#  * manually via workflow_dispatch (for ad-hoc refresh)
+
+on:
+  push:
+    branches: [main, master]
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  purge:
+    name: PURGE camo URLs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Wait for upstream sources to update
+        # On a fresh tag, shields.io/PyPI and coveralls.io may need a
+        # minute or two to register the new release — sleep so we don't
+        # purge too early and re-cache the still-old SVG.
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: sleep 60
+
+      - name: PURGE camo cache for all README badges
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Fetch the rendered README HTML (GitHub rewrites <img src> to
+          # camo.githubusercontent.com URLs in the rendered version).
+          rendered=$(curl -fsSL \
+            -H "Accept: application/vnd.github.html" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            "https://api.github.com/repos/${REPO}/readme")
+
+          urls=$(printf '%s' "$rendered" \
+                 | grep -oE 'https://camo\.githubusercontent\.com/[a-f0-9]+/[^"]*' \
+                 | sort -u)
+
+          if [ -z "$urls" ]; then
+            echo "No camo URLs found in rendered README — nothing to purge."
+            exit 0
+          fi
+
+          echo "Found $(echo "$urls" | wc -l | tr -d ' ') camo URL(s) to purge:"
+          echo "$urls"
+          echo
+
+          fail=0
+          while IFS= read -r url; do
+            [ -z "$url" ] && continue
+            code=$(curl -sI -X PURGE -o /dev/null -w '%{http_code}' "$url")
+            if [ "$code" = "200" ]; then
+              echo "  ok    $url"
+            else
+              echo "  HTTP $code  $url" >&2
+              fail=1
+            fi
+          done <<<"$urls"
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::warning::At least one PURGE failed; badges may stay stale until Camo's normal TTL expires."
+          fi


### PR DESCRIPTION
## Summary
After v1.0.17 shipped, the PyPI version badge in the README kept showing an older release until GitHub's Camo proxy refreshed (~24h TTL). shields.io itself was already serving the correct value — only the cached image GitHub injects via \`camo.githubusercontent.com\` was stale.

This adds a workflow that PURGEs every camo URL embedded in the rendered README, so the new release/coverage values flip immediately.

## Triggers
- Every push to \`main\` (in case the README itself changed)
- Every \`v*\` tag (so PyPI/AUR version badges flip on release)
- Manual \`workflow_dispatch\` for ad-hoc refresh

## How it works
1. Sleep 60s on tag push so shields.io/PyPI and coveralls.io have time to register the new release before we re-prime the cache.
2. Fetch the rendered README HTML via the GitHub API (which rewrites \`<img src>\` to \`camo.githubusercontent.com\`).
3. Extract each unique camo URL, send \`PURGE\`.
4. Report non-200 responses as a workflow warning rather than a hard failure (transient camo outages shouldn't fail the release pipeline).

## Test plan
- [x] YAML lint clean.
- [x] Manually verified \`curl -X PURGE\` on a live camo URL returns HTTP 200 (already used to fix the v1.0.17 stale-badge issue today).
- [ ] Will fire automatically on the next \`main\` push merging this PR; verify by re-checking the rendered README badges 1–2 min after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)