### PR TITLE
Bump version to 1.0.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "num2words2"
 # Static base version. The release CI overrides it from the pushed git tag
 # (see .github/workflows/release.yml); bump here for local source builds.
-version = "1.0.11"
+version = "1.0.18"
 license = "LGPL-2.1-only"
 license-files = ["COPYING"]
 description = "Rust port of the num2words conversion engine with a Python binder — number-to-words in 120+ languages, optimized for LLM/AI/speech."


### PR DESCRIPTION
Release num2words2 1.0.18 (Rust port). Next free tag above the stale v1.0.10–v1.0.17.