### PR TITLE
refactor: thin num2words2 Python binder (move all logic to Rust)

### DIFF
--- a/num2words2/__init__.py
+++ b/num2words2/__init__.py
@@ -16,18 +16,16 @@
 # MA 02110-1301 USA
 """num2words2 — a thin Python binder over the Rust conversion core.
 
-Every conversion is served by the compiled `_rust` extension: this module
-normalises the language code, maps the public keyword arguments onto the
-core's entry points, and applies the two string-level post-processing steps
-(`style=`, `cents=`) that are presentation, not conversion. There is no
-pure-Python conversion fallback — the core is authoritative, and an input it
-declines raises rather than silently diverging.
+Every conversion, and every piece of presentation logic that used to live
+here (language-code resolution, the ``style=`` post-processing, the ``cents=``
+mode mapping and the whole type dispatch), is now served by the compiled
+``_rust`` extension. This module is a pass-through: it re-exports the public
+entry points and the exception types, nothing more.
 """
 from __future__ import unicode_literals
 
-import decimal
-
-from .grouping import group_digits  # noqa: E402
+from . import _rust as _RUST
+from .grouping import group_digits  # noqa: F401  (re-exported)
 
 # Version information
 try:
@@ -37,21 +35,11 @@ except ImportError:
     __version__ = "unknown"
     __version_tuple__ = (0, 0, 0, "unknown", 0)
 
-
-# The compiled core is mandatory: this package is a binder over it.
-from . import _rust as _RUST  # noqa: E402
-
-_RUST_LANGS = frozenset(_RUST.supported_langs())
-_RUST_TYPES = frozenset(["cardinal", "ordinal", "ordinal_num", "year"])
-# The core's "declined" signal (see rust/num2words2-py/src/lib.rs). It is
-# distinct from NotImplementedError so a genuine NotImplementedError raise
-# propagates natively; here, with no Python conversion path behind it, a
-# decline is surfaced as NotImplementedError to the caller.
-_RUST_FALLBACK = _RUST.RustFallback
-
-# bn raises NumberTooLargeError past its MAX_NUMBER. The class used to live in
-# lang_BN.py; the pure binder defines it in the core and re-exports it here so
-# `from num2words2 import NumberTooLargeError` (and `except`) keep working.
+# Exception types defined in the compiled core and re-exported so
+# ``from num2words2 import NumberTooLargeError`` (and ``except`` on it) keep
+# working. RustFallback is the core's "declined" signal, kept importable for
+# the same reason.
+RustFallback = _RUST.RustFallback
 NumberTooLargeError = _RUST.NumberTooLargeError
 
 
@@ -72,226 +60,16 @@ CONVERTES_TYPES = [
 CONVERTER_TYPES = CONVERTES_TYPES  # Alias for compatibility
 
 
-def maxval(lang="en"):
-    """Return the maximum integer ``num2words(..., lang=lang)`` can convert.
-
-    Issue #582 ports savoirfairelinux/num2words#582.
-    """
-    return _RUST.maxval(lang)
-
-
-def _normalize_lang(lang):
-    """Resolve a caller's language code to a core key, mirroring the historic
-    dispatcher: exact match, then hyphen->underscore, then ``xx_YY`` casing,
-    then the bare two-letter prefix. Raises NotImplementedError if none match.
-    """
-    if lang in _RUST_LANGS:
-        return lang
-    nl = lang.replace("-", "_")
-    if nl in _RUST_LANGS:
-        return nl
-    parts = nl.split("_")
-    if len(parts) >= 2:
-        candidate = "%s_%s" % (parts[0].lower(), parts[1].upper())
-        if candidate in _RUST_LANGS:
-            return candidate
-        if parts[0] in _RUST_LANGS:
-            return parts[0]
-    if nl[:2] in _RUST_LANGS:
-        return nl[:2]
-    raise NotImplementedError()
-
-
-def _rust_kw_items(kwargs):
-    """kwargs -> [(k, v)] for the core boundary, or None when a value has a
-    type the boundary cannot carry (then the call is out of the core's
-    envelope and must raise)."""
-    items = []
-    for k, v in kwargs.items():
-        if v is None or isinstance(v, (bool, int, str)):
-            items.append((k, v))
-        elif isinstance(v, (list, tuple)) and all(
-                isinstance(x, str) for x in v):
-            items.append((k, list(v)))
-        else:
-            return None
-    return items
-
-
-def _apply_style(result, style, to, lang):
-    """`style=` presentation post-processing (issues #535, #562). Operates on
-    the rendered string, so it is conversion-independent."""
-    if style == "terse" and to == "ordinal" and isinstance(result, str):
-        for prefix in ("one ", "un ", "uno "):
-            if result.startswith(prefix) and len(result) > len(prefix):
-                result = result[len(prefix):]
-                break
-    if style == "us" and lang.startswith("en") and isinstance(result, str):
-        result = result.replace(" and ", " ")
-    return result
-
-
-def _normalize_cents(kwargs):
-    """`cents='omit'|'verbose'|'terse'` -> the legacy bool the core expects
-    (issue #554). Returns (cents_bool, drop_cents) where drop_cents means the
-    float value should be truncated to an int so no cents segment appears."""
-    cents_kw = kwargs.get("cents", True)
-    if cents_kw == "omit":
-        return True, True
-    if cents_kw == "verbose":
-        return True, False
-    if cents_kw == "terse":
-        return False, False
-    return cents_kw, False
-
-
 def num2words(number, ordinal=False, lang="en", to="cardinal", **kwargs):
-    # Captured before any normalisation: the core keys off the *arrival* type
-    # (a plain int vs a float/Decimal vs a str), not a post-parse value.
-    _plain_int = type(number) is int
-    _plain_num = isinstance(number, (float, decimal.Decimal))
-
-    lang = _normalize_lang(lang)
-    _style = kwargs.get("style")
-
-    # ---- string input: the core's from_string owns the whole pipeline
-    # (fraction strings, str_to_number incl. the ES "1ro" / pt_BR "ponto"
-    # handshakes, mixed text -> sentence, then the mode dispatch).
-    if isinstance(number, str):
-        _to_final = "ordinal" if ordinal else to
-        if _to_final not in CONVERTES_TYPES:
-            raise NotImplementedError()
-        _cents, _ = _normalize_cents(kwargs)
-        _extras = {k: v for k, v in kwargs.items()
-                   if k not in ("currency", "cents", "separator",
-                                "adjective", "style", "precision")}
-        _items = _rust_kw_items(_extras)
-        if _cents not in (True, False) or _items is None:
-            raise NotImplementedError()
-        try:
-            _kind, _out = _RUST.from_string(
-                lang, number, _to_final, kwargs.get("currency"), _cents,
-                kwargs.get("separator"), kwargs.get("adjective"), _items)
-        except _RUST_FALLBACK:
-            raise NotImplementedError()
-        if _kind != 0:
-            raise NotImplementedError()
-        return _apply_style(_out, _style, _to_final, lang)
-
-    # backwards compatible
-    if ordinal:
-        to = "ordinal"
-    if to not in CONVERTES_TYPES:
-        raise NotImplementedError()
-
-    _precision = kwargs.get("precision")
-    _extras = {k: v for k, v in kwargs.items()
-               if k not in ("style", "precision")}
-
-    # ---- integer modes with a plain int
-    if _plain_int and to in _RUST_TYPES:
-        _items = _rust_kw_items(_extras)
-        if _items is not None:
-            try:
-                if _items:
-                    result = getattr(_RUST, "to_%s_kw" % to)(
-                        lang, number, _items)
-                else:
-                    result = getattr(_RUST, "to_%s" % to)(lang, number)
-            except _RUST_FALLBACK:
-                raise NotImplementedError()
-            return _apply_style(result, _style, to, lang)
-
-    # ---- float / Decimal, all four integer modes
-    if _plain_num and to in _RUST_TYPES:
-        try:
-            _finite = float(number) == float(number) and float(
-                number) not in (float("inf"), float("-inf"))
-        except (OverflowError, ValueError):
-            _finite = False
-        _fitems = {k: v for k, v in _extras.items()
-                   if k not in ("currency", "cents", "separator", "adjective")}
-        _items = _rust_kw_items(_fitems)
-        if _finite and _items is not None:
-            _prec = abs(decimal.Decimal(str(number)).as_tuple().exponent)
-            _dec = str(number) if isinstance(number, decimal.Decimal) else ""
-            try:
-                result = _RUST.to_float(
-                    lang, to, float(number), _prec, _dec, str(number),
-                    _precision, _items)
-            except _RUST_FALLBACK:
-                raise NotImplementedError()
-            return _apply_style(result, _style, to, lang)
-
-    # ---- currency
-    if to == "currency" and isinstance(number, (int, float, decimal.Decimal)):
-        _cents, _drop = _normalize_cents(kwargs)
-        if _drop and isinstance(number, float):
-            number = int(number)  # int path drops cents naturally
-        if _cents in (True, False):
-            _citems = {k: v for k, v in _extras.items()
-                       if k not in ("currency", "cents", "separator",
-                                    "adjective")}
-            _items = _rust_kw_items(_citems)
-            if _items is not None:
-                _args = (
-                    lang, str(number), type(number) is int,
-                    isinstance(number, float) or "." in str(number),
-                    isinstance(number, float),
-                    kwargs.get("currency"), _cents,
-                    kwargs.get("separator"), kwargs.get("adjective"),
-                )
-                try:
-                    if _items:
-                        return _RUST.to_currency_kw(*_args, _items)
-                    return _RUST.to_currency(*_args)
-                except _RUST_FALLBACK:
-                    raise NotImplementedError()
-
-    if to == "cheque" and isinstance(number, (int, float, decimal.Decimal)):
-        try:
-            return _RUST.to_cheque(lang, str(number), kwargs.get("currency"))
-        except _RUST_FALLBACK:
-            raise NotImplementedError()
-
-    # to='fraction' with a non-string number: the historic dispatcher fed the
-    # value straight to converter.to_fraction(value). A single positional (the
-    # tuple ``(1, 2)``) raised TypeError where the method exists, or
-    # AttributeError where it does not (bn/dv/id have no to_fraction). Probe
-    # the core to tell them apart; genuine "n/d" fractions arrive as strings
-    # and are served by from_string above.
-    if to == "fraction":
-        try:
-            _RUST.to_fraction(lang, 1, 1)
-        except AttributeError:
-            raise
-        except Exception:  # noqa: BLE001 - probing for the method's existence
-            pass
-        raise TypeError(
-            "to_fraction() missing 1 required positional argument: "
-            "'denominator'")
-
-    raise NotImplementedError()
+    return _RUST.num2words(number, ordinal, lang, to, **kwargs)
 
 
 def num2words_sentence(sentence, lang="en", to="cardinal", **kwargs):
-    """Convert every number in a sentence to words.
+    return _RUST.num2words_sentence(sentence, lang, to, **kwargs)
 
-    `lang=None` auto-detects (lingua-rs in the full build). Handles ordinals,
-    currency, dates, temperatures and plain numbers, splicing each conversion
-    back in place.
 
-    >>> num2words_sentence("I bought 6 apples")
-    'I bought six apples'
-    >>> num2words_sentence("The 1st place winner got $100")
-    'The first place winner got one hundred dollars, zero cents'
-    """
-    if lang is None:
-        return _RUST.sentence_auto(sentence, to)
-    # The core's sentence converter does its own lang validation (and the
-    # same two-letter-prefix fallback), raising NotImplementedError for an
-    # unsupported language exactly as the historic dispatcher did.
-    return _RUST.sentence(sentence, lang, to)
+def maxval(lang="en"):
+    return _RUST.maxval(lang)
 
 
 # Aliases for num2words_sentence

--- a/num2words2/grouping.py
+++ b/num2words2/grouping.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2026, num2words2 contributors. All Rights Reserved.
 # Licensed under LGPL-2.1 (see COPYING).
-"""Number-string grouping helpers.
+"""Number-string grouping — thin binder over the Rust core.
 
 Some locales group digits in patterns other than the standard ``,###``
-Western convention.  This module exposes a single helper, :func:`group_digits`,
-that returns the locale-grouped form of an integer.
+Western convention.  :func:`group_digits` returns the locale-grouped form of an
+integer; all logic lives in the ``num2words2._rust`` extension.
 
 Currently supported groupings:
 
@@ -18,12 +18,7 @@ Issue #66; ports the request in savoirfairelinux/num2words#547.
 
 from __future__ import unicode_literals
 
-# Independent of the package __init__ (no circular import): the extension
-# module is importable on its own. Absent -> pure-Python behaviour.
-try:
-    from . import _rust as _RUST
-except ImportError:  # pragma: no cover - depends on build
-    _RUST = None
+from . import _rust as _RUST
 
 
 def group_digits(value, locale="western", separator=","):
@@ -33,38 +28,9 @@ def group_digits(value, locale="western", separator=","):
     --------
     >>> group_digits(100000, locale="indian")
     '1,00,000'
-    >>> group_digits(12345678, locale="indian")
-    '1,23,45,678'
     >>> group_digits(1234567, locale="western")
     '1,234,567'
     >>> group_digits(12345678, locale="chinese")
     '1234,5678'
     """
-    if not isinstance(value, int):
-        raise TypeError("group_digits requires an int, got %r" % type(value))
-    # The isinstance check stays here: its TypeError message needs Python's
-    # %r of the type object. Everything after it is pure string work.
-    if _RUST is not None:
-        return _RUST.group_digits(value, locale, separator)
-    sign = "-" if value < 0 else ""
-    s = str(abs(value))
-
-    if locale == "western":
-        return sign + _group(s, 3, separator)
-    if locale == "indian":
-        # Last three digits, then groups of two on the high side.
-        if len(s) <= 3:
-            return sign + s
-        last3, rest = s[-3:], s[:-3]
-        return sign + _group(rest, 2, separator) + separator + last3
-    if locale == "chinese":
-        return sign + _group(s, 4, separator)
-    raise ValueError("Unknown locale: %r" % locale)
-
-
-def _group(s, size, separator):
-    out = []
-    while s:
-        out.append(s[-size:])
-        s = s[:-size]
-    return separator.join(reversed(out))
+    return _RUST.group_digits(value, locale, separator)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "num2words2-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bigdecimal",
  "num-bigint",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "num2words2-py"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bigdecimal",
  "lingua",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["num2words2-core", "num2words2-py"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/jqueguiner/num2words2"

--- a/rust/num2words2-core/src/lib.rs
+++ b/rust/num2words2-core/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod base;
 pub mod currency;
 pub mod floatpath;
+pub mod presentation;
 pub mod strnum;
 pub mod lang_af;
 pub mod lang_am;

--- a/rust/num2words2-core/src/presentation.rs
+++ b/rust/num2words2-core/src/presentation.rs
@@ -1,0 +1,175 @@
+//! Presentation / dispatch helpers ported from `num2words2/__init__.py`.
+//!
+//! These three functions were the last pieces of pure-Python logic living in
+//! the `num2words2` binder: language-code resolution, the `style=`
+//! post-processing, and the `cents=` mode mapping. They are conversion-agnostic
+//! string/enum transforms, so they belong in the pure core rather than the
+//! Python surface. The PyO3 binder classifies the caller's arguments into the
+//! plain types below and calls these directly.
+
+/// Resolve a caller's language code to a core key, mirroring the historic
+/// dispatcher (`num2words2.__init__._normalize_lang`):
+///
+/// 1. exact match, then
+/// 2. hyphen -> underscore, then
+/// 3. `xx_YY` casing, then
+/// 4. the bare two-letter prefix.
+///
+/// Returns `None` when none match; the binder turns that into the same empty
+/// `NotImplementedError` the Python raised.
+pub fn resolve_lang(raw: &str) -> Option<String> {
+    let keys = crate::supported_lang_keys();
+    // `keys.contains(&s)` cannot be used: the keys are `&'static str` and the
+    // needle is a borrowed `&str`, so the slice `contains` type-checks fail.
+    #[allow(clippy::manual_contains)]
+    let known = |s: &str| keys.iter().any(|k| *k == s);
+
+    if known(raw) {
+        return Some(raw.to_string());
+    }
+    let nl = raw.replace('-', "_");
+    if known(&nl) {
+        return Some(nl);
+    }
+    let parts: Vec<&str> = nl.split('_').collect();
+    if parts.len() >= 2 {
+        let candidate = format!("{}_{}", parts[0].to_lowercase(), parts[1].to_uppercase());
+        if known(&candidate) {
+            return Some(candidate);
+        }
+        if known(parts[0]) {
+            return Some(parts[0].to_string());
+        }
+    }
+    let prefix: String = nl.chars().take(2).collect();
+    if known(&prefix) {
+        return Some(prefix);
+    }
+    None
+}
+
+/// `style=` presentation post-processing (issues #535, #562), mirroring
+/// `num2words2.__init__._apply_style`. Operates on the rendered string, so it
+/// is conversion-independent:
+///
+/// * `style="terse"` + `to == "ordinal"` strips a leading `"one "`/`"un "`/
+///   `"uno "` (but never reduces the whole string to empty).
+/// * `style="us"` + an English `lang` replaces `" and "` with `" "`.
+pub fn apply_style(result: &str, style: Option<&str>, to: &str, lang: &str) -> String {
+    let mut out = result.to_string();
+    if style == Some("terse") && to == "ordinal" {
+        for prefix in ["one ", "un ", "uno "] {
+            if out.starts_with(prefix) && out.len() > prefix.len() {
+                out = out[prefix.len()..].to_string();
+                break;
+            }
+        }
+    }
+    if style == Some("us") && lang.starts_with("en") {
+        out = out.replace(" and ", " ");
+    }
+    out
+}
+
+/// The `cents=` argument as the binder classifies the caller's Python object.
+pub enum CentsArg<'a> {
+    /// The kwarg was not supplied at all (Python default `True`).
+    Absent,
+    /// A real Python `bool`.
+    Bool(bool),
+    /// A Python `str` (only the three keywords are meaningful).
+    Str(&'a str),
+    /// Any other type — Python keeps it as-is, and the caller's
+    /// `_cents in (True, False)` guard then rejects it.
+    Other,
+}
+
+/// `cents='omit'|'verbose'|'terse'` -> the legacy bool the core expects
+/// (issue #554), mirroring `num2words2.__init__._normalize_cents` **plus** the
+/// caller's follow-up `_cents in (True, False)` guard.
+///
+/// Returns `Some((cents_bool, drop_cents))` when the value resolves to a usable
+/// bool (absent, a real bool, or one of the three keywords); `drop_cents` means
+/// the value should be truncated to an int so no cents segment appears.
+/// Returns `None` when Python would have kept a non-bool value and the guard
+/// would reject it (the binder then declines the call).
+pub fn normalize_cents(cents: CentsArg) -> Option<(bool, bool)> {
+    match cents {
+        CentsArg::Absent => Some((true, false)),
+        CentsArg::Str("omit") => Some((true, true)),
+        CentsArg::Str("verbose") => Some((true, false)),
+        CentsArg::Str("terse") => Some((false, false)),
+        CentsArg::Bool(b) => Some((b, false)),
+        CentsArg::Str(_) | CentsArg::Other => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_exact_and_hyphen() {
+        assert_eq!(resolve_lang("en").as_deref(), Some("en"));
+        assert_eq!(resolve_lang("pt_BR").as_deref(), Some("pt_BR"));
+        // hyphen -> underscore, exact key
+        assert_eq!(resolve_lang("pt-BR").as_deref(), Some("pt_BR"));
+    }
+
+    #[test]
+    fn resolve_casing_and_prefix() {
+        // en-US: no en_US key, casing candidate missing, prefix "en" wins.
+        assert_eq!(resolve_lang("en-US").as_deref(), Some("en"));
+        assert_eq!(resolve_lang("en_US").as_deref(), Some("en"));
+        // Two-letter-prefix fallback on a longer word.
+        assert_eq!(resolve_lang("english").as_deref(), Some("en"));
+    }
+
+    #[test]
+    fn resolve_unknown() {
+        assert_eq!(resolve_lang("unknown_lang"), None);
+        assert_eq!(resolve_lang("zz"), None);
+    }
+
+    #[test]
+    fn style_terse_strips_leading_one() {
+        assert_eq!(
+            apply_style("one hundredth", Some("terse"), "ordinal", "en"),
+            "hundredth"
+        );
+        // Exactly "first" is untouched (no leading "one ").
+        assert_eq!(apply_style("first", Some("terse"), "ordinal", "en"), "first");
+        // terse only applies to ordinal.
+        assert_eq!(
+            apply_style("one hundred", Some("terse"), "cardinal", "en"),
+            "one hundred"
+        );
+    }
+
+    #[test]
+    fn style_us_drops_and() {
+        assert_eq!(
+            apply_style("one thousand and one", Some("us"), "cardinal", "en"),
+            "one thousand one"
+        );
+        // Non-English lang is untouched.
+        assert_eq!(
+            apply_style("mil y uno", Some("us"), "cardinal", "es"),
+            "mil y uno"
+        );
+        // No style is a no-op.
+        assert_eq!(apply_style("x and y", None, "cardinal", "en"), "x and y");
+    }
+
+    #[test]
+    fn cents_modes() {
+        assert_eq!(normalize_cents(CentsArg::Absent), Some((true, false)));
+        assert_eq!(normalize_cents(CentsArg::Str("omit")), Some((true, true)));
+        assert_eq!(normalize_cents(CentsArg::Str("verbose")), Some((true, false)));
+        assert_eq!(normalize_cents(CentsArg::Str("terse")), Some((false, false)));
+        assert_eq!(normalize_cents(CentsArg::Bool(true)), Some((true, false)));
+        assert_eq!(normalize_cents(CentsArg::Bool(false)), Some((false, false)));
+        assert_eq!(normalize_cents(CentsArg::Str("nope")), None);
+        assert_eq!(normalize_cents(CentsArg::Other), None);
+    }
+}

--- a/rust/num2words2-py/src/lib.rs
+++ b/rust/num2words2-py/src/lib.rs
@@ -11,6 +11,7 @@ mod sentencepath;
 
 use bigdecimal::BigDecimal;
 use num2words2_core::base::{Kwargs, KwVal, Lang};
+use num2words2_core::presentation::{self, CentsArg};
 use num2words2_core::strnum::{
     has_py_digit, python_decimal_str, python_int_parse, ParsedNumber,
 };
@@ -22,7 +23,27 @@ use pyo3::exceptions::{
     PyOverflowError, PyRuntimeError, PyTypeError, PyValueError, PyZeroDivisionError,
 };
 use pyo3::prelude::*;
+use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyList, PyString, PyStringMethods, PyTuple};
 use std::str::FromStr;
+
+/// Modes that map to a value-type entry point (`_RUST_TYPES` in the old shim).
+const RUST_TYPES: [&str; 4] = ["cardinal", "ordinal", "ordinal_num", "year"];
+/// Every `to=` the dispatcher accepts (`CONVERTES_TYPES` in the old shim).
+const CONVERTER_TYPES: [&str; 7] = [
+    "cardinal",
+    "ordinal",
+    "ordinal_num",
+    "year",
+    "currency",
+    "cheque",
+    "fraction",
+];
+
+/// The empty-message `NotImplementedError` the old Python shim raised
+/// (`raise NotImplementedError()`), reproduced exactly.
+fn not_implemented() -> PyErr {
+    PyNotImplementedError::new_err("")
+}
 
 // The Rust-core-declines signal. NOT a NotImplementedError subclass: the
 // shim catches THIS to fall back to the original Python converter, while a
@@ -126,14 +147,22 @@ fn kwbag(kwargs: PyKwargs) -> Kwargs {
     )
 }
 
-/// Unwrap a conversion result the way every entry point must: lang_VI's
-/// bare-`None` return becomes Python None, everything else maps through.
-fn finish(r: Result<String, N2WError>) -> PyResult<Option<String>> {
+/// lang_VI's bare-`None` return becomes `Ok(None)`; every other error stays an
+/// error. Kept in `N2WError` space so the caller decides how to map it (the
+/// unified `num2words` entry turns `Fallback` into `NotImplementedError`, while
+/// the standalone entry points surface it as `RustFallback`).
+fn opt(r: Result<String, N2WError>) -> Result<Option<String>, N2WError> {
     match r {
         Ok(s) => Ok(Some(s)),
         Err(N2WError::ReturnsNone) => Ok(None),
-        Err(e) => Err(map_err(e)),
+        Err(e) => Err(e),
     }
+}
+
+/// Unwrap a conversion result the way every entry point must: lang_VI's
+/// bare-`None` return becomes Python None, everything else maps through.
+fn finish(r: Result<String, N2WError>) -> PyResult<Option<String>> {
+    opt(r).map_err(map_err)
 }
 
 #[pyfunction]
@@ -208,7 +237,7 @@ fn to_cardinal_float(
     precision_override: Option<u32>,
 ) -> PyResult<Option<String>> {
     let l = need_lang(lang)?;
-    let v = float_value(l, value, precision, decimal_str)?;
+    let v = float_value(value, precision, decimal_str).map_err(map_err)?;
     finish(l.cardinal_float_entry(&v, precision_override))
 }
 
@@ -225,21 +254,15 @@ fn to_cardinal_float_raw(
     precision_override: Option<u32>,
 ) -> PyResult<Option<String>> {
     let l = need_lang(lang)?;
-    let v = float_value(l, value, precision, decimal_str)?;
+    let v = float_value(value, precision, decimal_str).map_err(map_err)?;
     finish(l.to_cardinal_float(&v, precision_override))
 }
 
-fn float_value(
-    l: &'static (dyn Lang + Sync),
-    value: f64,
-    precision: u32,
-    decimal_str: &str,
-) -> PyResult<FloatValue> {
+fn float_value(value: f64, precision: u32, decimal_str: &str) -> Result<FloatValue, N2WError> {
     if decimal_str.is_empty() {
         Ok(FloatValue::Float { value, precision })
     } else {
-        let d = BigDecimal::from_str(decimal_str)
-            .map_err(|e| PyValueError::new_err(e.to_string()))?;
+        let d = BigDecimal::from_str(decimal_str).map_err(|e| N2WError::Value(e.to_string()))?;
         use bigdecimal::num_traits::Zero;
         // BigDecimal cannot carry Decimal("-0.0")'s sign. For zero, both
         // float2tuple arms produce pre=0/post=0, so demoting to the float
@@ -279,21 +302,46 @@ fn to_float(
     kwargs: PyKwargs,
 ) -> PyResult<Option<String>> {
     let l = need_lang(lang)?;
-    let kw = kwbag(kwargs);
+    to_float_core(
+        l,
+        to,
+        value,
+        precision,
+        decimal_str,
+        repr_str,
+        precision_override,
+        &kwbag(kwargs),
+    )
+    .map_err(map_err)
+}
+
+/// The float/Decimal router, factored so both the `to_float` entry point and
+/// the unified `num2words` dispatcher share one implementation.
+#[allow(clippy::too_many_arguments)]
+fn to_float_core(
+    l: &'static (dyn Lang + Sync),
+    to: &str,
+    value: f64,
+    precision: u32,
+    decimal_str: &str,
+    repr_str: &str,
+    precision_override: Option<u32>,
+    kw: &Kwargs,
+) -> Result<Option<String>, N2WError> {
     // Decimal('-0.0') the language renders specially (BigDecimal can't hold
     // the sign) — serve it natively before the demotion to Float{-0.0}.
     if is_neg_zero_decimal(decimal_str, value) && kw.is_empty() {
         if let Some(res) = l.neg_zero_decimal(to) {
-            return finish(res);
+            return opt(res);
         }
     }
-    let v = float_value(l, value, precision, decimal_str)?;
+    let v = float_value(value, precision, decimal_str)?;
     let r = match to {
         "cardinal" => {
             if kw.is_empty() {
                 l.cardinal_float_entry(&v, precision_override)
             } else {
-                l.to_cardinal_float_kw(&v, precision_override, &kw)
+                l.to_cardinal_float_kw(&v, precision_override, kw)
             }
         }
         // kwargs on the non-cardinal float modes stay on the Python side.
@@ -315,7 +363,7 @@ fn to_float(
         "year" => l.year_float_entry(&v),
         other => Err(N2WError::Fallback(other.to_string())),
     };
-    finish(r)
+    opt(r)
 }
 
 #[pyfunction]
@@ -386,8 +434,33 @@ fn from_string(
     kwargs: PyKwargs,
 ) -> PyResult<(u8, Option<String>)> {
     let l = need_lang(lang)?;
-    let kw = kwbag(kwargs);
+    from_string_core(
+        l,
+        lang,
+        s,
+        to,
+        currency,
+        cents,
+        separator,
+        adjective,
+        &kwbag(kwargs),
+    )
+}
 
+/// The string-input router, factored so both the `from_string` entry point and
+/// the unified `num2words` dispatcher share one implementation.
+#[allow(clippy::too_many_arguments)]
+fn from_string_core(
+    l: &'static (dyn Lang + Sync),
+    lang: &str,
+    s: &str,
+    to: &str,
+    currency: Option<&str>,
+    cents: bool,
+    separator: Option<&str>,
+    adjective: Option<bool>,
+    kw: &Kwargs,
+) -> PyResult<(u8, Option<String>)> {
     // "n/d" fraction strings route straight to to_fraction, whatever `to`
     // says — mirroring the dispatcher, where this check precedes the mode
     // dispatch entirely.
@@ -492,7 +565,7 @@ fn from_string(
                 }
                 // fraction: getattr TypeError (missing denominator), same as
                 // any int -> int_mode reproduces it.
-                _ => int_mode(l, to, &n, &kw, currency, cents, separator, adjective),
+                _ => int_mode(l, to, &n, kw, currency, cents, separator, adjective),
             }
         }
         ParsedNumber::DecPoint { value, pointword } => {
@@ -500,11 +573,11 @@ fn from_string(
             let fv = FloatValue::Decimal { value: value.clone(), precision: prec };
             match to {
                 "cardinal" if kw.is_empty() => l.cardinal_with_pointword(&fv, pointword, None),
-                _ => dec_mode(l, to, &value, &kw, currency, cents, separator, adjective),
+                _ => dec_mode(l, to, &value, kw, currency, cents, separator, adjective),
             }
         }
         ParsedNumber::Dec(value) => {
-            dec_mode(l, to, &value, &kw, currency, cents, separator, adjective)
+            dec_mode(l, to, &value, kw, currency, cents, separator, adjective)
         }
         // Inf/NaN behaviour is per-language: base raises OverflowError /
         // ValueError, but the self-contained converters that int() the raw
@@ -622,12 +695,443 @@ fn dec_mode(
 }
 
 #[pyfunction]
+#[pyo3(signature = (lang, value, currency=None))]
 fn to_cheque(lang: &str, value: &str, currency: Option<&str>) -> PyResult<Option<String>> {
-    let l = need_lang(lang)?;
+    cheque_core(need_lang(lang)?, value, currency).map_err(map_err)
+}
+
+/// The cheque router, shared by the `to_cheque` entry point and `num2words`.
+fn cheque_core(
+    l: &'static (dyn Lang + Sync),
+    value: &str,
+    currency: Option<&str>,
+) -> Result<Option<String>, N2WError> {
     let currency = currency.unwrap_or(l.default_currency());
-    let d = BigDecimal::from_str(value)
-        .map_err(|e| PyValueError::new_err(e.to_string()))?;
-    finish(l.to_cheque(&d, currency))
+    let d = BigDecimal::from_str(value).map_err(|e| N2WError::Value(e.to_string()))?;
+    opt(l.to_cheque(&d, currency))
+}
+
+/// The whole-number int modes (`_RUST_TYPES`), shared by `num2words`. Mirrors
+/// the shim's `getattr(_RUST, "to_%s[_kw]" % to)(...)`: the `_kw` variant only
+/// when kwargs are present.
+fn int_int_mode(
+    l: &'static (dyn Lang + Sync),
+    to: &str,
+    n: &BigInt,
+    kw: &Kwargs,
+) -> Result<Option<String>, N2WError> {
+    let r = match to {
+        "cardinal" if kw.is_empty() => l.to_cardinal(n),
+        "cardinal" => l.to_cardinal_kw(n, kw),
+        "ordinal" if kw.is_empty() => l.to_ordinal(n),
+        "ordinal" => l.to_ordinal_kw(n, kw),
+        "ordinal_num" if kw.is_empty() => l.to_ordinal_num(n),
+        "ordinal_num" => l.to_ordinal_num_kw(n, kw),
+        "year" if kw.is_empty() => l.to_year(n),
+        "year" => l.to_year_kw(n, kw),
+        // int_int_mode is only ever called with `to` in RUST_TYPES.
+        other => Err(N2WError::Fallback(other.to_string())),
+    };
+    opt(r)
+}
+
+/// The currency router, shared by `num2words`. Mirrors the shim's
+/// `to_currency[_kw]` selection (the `_kw` variant only when kwargs present).
+#[allow(clippy::too_many_arguments)]
+fn currency_core(
+    l: &'static (dyn Lang + Sync),
+    value: &str,
+    is_int: bool,
+    has_decimal: bool,
+    is_float: bool,
+    currency: Option<&str>,
+    cents: bool,
+    separator: Option<&str>,
+    adjective: Option<bool>,
+    kw: &Kwargs,
+) -> Result<Option<String>, N2WError> {
+    let v = CurrencyValue::parse(value, is_int, has_decimal, is_float)?;
+    let adjective = adjective.unwrap_or(l.default_adjective());
+    let currency = currency.unwrap_or(l.default_currency());
+    let r = if kw.is_empty() {
+        l.to_currency(&v, currency, cents, separator, adjective)
+    } else {
+        l.to_currency_kw(&v, currency, cents, separator, adjective, kw)
+    };
+    opt(r)
+}
+
+/// `to='fraction'` with a non-string number. The shim probed
+/// `_RUST.to_fraction(lang, 1, 1)`: an `AttributeError` (BN/ID/DV have no
+/// `to_fraction`) re-raises, anything else becomes the missing-`denominator`
+/// `TypeError`.
+fn fraction_probe(l: &'static (dyn Lang + Sync)) -> N2WError {
+    match l.to_fraction(&BigInt::from(1), &BigInt::from(1)) {
+        Err(e @ N2WError::Attribute(_)) => e,
+        _ => N2WError::Type(
+            "to_fraction() missing 1 required positional argument: 'denominator'".into(),
+        ),
+    }
+}
+
+// --- Argument classification for the unified `num2words` entry -------------
+
+/// `str(obj)` as a Rust `String`.
+fn pystr(obj: &Bound<'_, PyAny>) -> PyResult<String> {
+    Ok(obj.str()?.to_cow()?.into_owned())
+}
+
+/// `kwargs.get(key)` — `None` for a missing key.
+fn dict_get<'py>(
+    kwargs: Option<&Bound<'py, PyDict>>,
+    key: &str,
+) -> PyResult<Option<Bound<'py, PyAny>>> {
+    match kwargs {
+        Some(d) => d.get_item(key),
+        None => Ok(None),
+    }
+}
+
+/// `kwargs.get("style")` reduced to the string the post-processor compares
+/// against ("terse"/"us"); a non-str value can never match and becomes None.
+fn get_style(kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<Option<String>> {
+    Ok(dict_get(kwargs, "style")?.and_then(|v| v.extract::<String>().ok()))
+}
+
+/// An `Option<&str>` kwarg (`currency`/`separator`): missing or explicit `None`
+/// -> None; a str -> Some; anything else raises TypeError exactly as passing it
+/// to the old pyfunction did.
+fn get_opt_str(kwargs: Option<&Bound<'_, PyDict>>, key: &str) -> PyResult<Option<String>> {
+    match dict_get(kwargs, key)? {
+        Some(v) if !v.is_none() => Ok(Some(v.extract::<String>()?)),
+        _ => Ok(None),
+    }
+}
+
+/// `adjective` — an `Option<bool>` kwarg with the same rules as `get_opt_str`.
+fn get_opt_bool(kwargs: Option<&Bound<'_, PyDict>>, key: &str) -> PyResult<Option<bool>> {
+    match dict_get(kwargs, key)? {
+        Some(v) if !v.is_none() => Ok(Some(v.extract::<bool>()?)),
+        _ => Ok(None),
+    }
+}
+
+/// `precision` — an `Option<u32>` kwarg.
+fn get_precision(kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<Option<u32>> {
+    match dict_get(kwargs, "precision")? {
+        Some(v) if !v.is_none() => Ok(Some(v.extract::<u32>()?)),
+        _ => Ok(None),
+    }
+}
+
+/// Classify the `cents=` object and run the core's normalisation + guard.
+fn classify_cents(kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<Option<(bool, bool)>> {
+    Ok(match dict_get(kwargs, "cents")? {
+        None => presentation::normalize_cents(CentsArg::Absent),
+        Some(v) => {
+            if v.is_none() {
+                presentation::normalize_cents(CentsArg::Other)
+            } else if let Ok(b) = v.downcast::<PyBool>() {
+                presentation::normalize_cents(CentsArg::Bool(b.is_true()))
+            } else if let Ok(s) = v.extract::<String>() {
+                presentation::normalize_cents(CentsArg::Str(&s))
+            } else {
+                presentation::normalize_cents(CentsArg::Other)
+            }
+        }
+    })
+}
+
+/// Marshal the caller's kwargs into a `Kwargs` bag, skipping `skip` keys.
+/// Returns `None` when a value has a type the core cannot carry — the shim's
+/// `_rust_kw_items` returning None, which makes the caller decline the branch.
+fn extras_to_kwargs(
+    kwargs: Option<&Bound<'_, PyDict>>,
+    skip: &[&str],
+) -> PyResult<Option<Kwargs>> {
+    let dict = match kwargs {
+        Some(d) => d,
+        None => return Ok(Some(Kwargs::default())),
+    };
+    let mut out: Vec<(String, KwVal)> = Vec::new();
+    for (k, v) in dict.iter() {
+        let key: String = k.extract()?;
+        if skip.contains(&key.as_str()) {
+            continue;
+        }
+        // Order mirrors `isinstance(v, (bool, int, str))` then `(list, tuple)`:
+        // bool before int (a Python bool is an int).
+        let val = if v.is_none() {
+            KwVal::None
+        } else if let Ok(b) = v.downcast::<PyBool>() {
+            KwVal::Bool(b.is_true())
+        } else if v.is_instance_of::<PyInt>() {
+            match v.extract::<i64>() {
+                Ok(i) => KwVal::Int(i),
+                // A plain int the core cannot carry -> decline the whole bag.
+                Err(_) => return Ok(None),
+            }
+        } else if let Ok(s) = v.extract::<String>() {
+            KwVal::Str(s)
+        } else if v.is_instance_of::<PyList>() || v.is_instance_of::<PyTuple>() {
+            let mut items: Vec<String> = Vec::new();
+            let mut all_str = true;
+            for x in v.try_iter()? {
+                match x?.extract::<String>() {
+                    Ok(s) => items.push(s),
+                    Err(_) => {
+                        all_str = false;
+                        break;
+                    }
+                }
+            }
+            if all_str {
+                KwVal::List(items)
+            } else {
+                return Ok(None);
+            }
+        } else {
+            return Ok(None);
+        };
+        out.push((key, val));
+    }
+    Ok(Some(Kwargs(out)))
+}
+
+/// abs(exponent) of `Decimal(str(number))` — the shim's fractional-precision
+/// computation. BigDecimal parses the same repr forms (`"1.5"`, `"1e-05"`, ...)
+/// and yields the identical scale.
+fn decimal_scale(s: &str) -> u32 {
+    BigDecimal::from_str(s)
+        .map(|d| d.as_bigint_and_exponent().1.unsigned_abs() as u32)
+        .unwrap_or(0)
+}
+
+/// The whole of the old `num2words2.__init__.num2words` pipeline: number-type
+/// classification, language resolution, mode dispatch and the `style=`
+/// post-processing — so the Python surface is a straight pass-through.
+#[pyfunction]
+#[pyo3(signature = (number, ordinal=false, lang="en", to="cardinal", **kwargs))]
+fn num2words(
+    py: Python<'_>,
+    number: &Bound<'_, PyAny>,
+    ordinal: bool,
+    lang: &str,
+    to: &str,
+    kwargs: Option<&Bound<'_, PyDict>>,
+) -> PyResult<Option<String>> {
+    // Captured before any normalisation: the core keys off the *arrival* type
+    // (a plain int vs a float/Decimal vs a str), not a post-parse value.
+    let is_str = number.is_instance_of::<PyString>();
+    let plain_int = number.is_exact_instance_of::<PyInt>(); // type(number) is int
+    let intish = number.is_instance_of::<PyInt>(); // isinstance(number, int) — incl. bool
+    let is_float = number.is_instance_of::<PyFloat>();
+    // Only import `decimal` for objects that could actually be a Decimal.
+    let is_decimal = if is_str || is_float || intish {
+        false
+    } else {
+        let decimal_cls = py.import("decimal")?.getattr("Decimal")?;
+        number.is_instance(&decimal_cls)?
+    };
+    let plain_num = is_float || is_decimal;
+
+    let resolved = presentation::resolve_lang(lang).ok_or_else(not_implemented)?;
+    let lang = resolved.as_str();
+    let l = need_lang(lang)?;
+    let style = get_style(kwargs)?;
+
+    // ---- string input: from_string owns the whole pipeline.
+    if is_str {
+        let s: String = number.extract()?;
+        let to_final = if ordinal { "ordinal" } else { to };
+        if !CONVERTER_TYPES.contains(&to_final) {
+            return Err(not_implemented());
+        }
+        let cents = classify_cents(kwargs)?;
+        let extras = extras_to_kwargs(
+            kwargs,
+            &[
+                "currency",
+                "cents",
+                "separator",
+                "adjective",
+                "style",
+                "precision",
+            ],
+        )?;
+        let (cents_bool, kw) = match (cents, extras) {
+            (Some((c, _drop)), Some(kw)) => (c, kw),
+            _ => return Err(not_implemented()),
+        };
+        let currency = get_opt_str(kwargs, "currency")?;
+        let separator = get_opt_str(kwargs, "separator")?;
+        let adjective = get_opt_bool(kwargs, "adjective")?;
+        return match from_string_core(
+            l,
+            lang,
+            &s,
+            to_final,
+            currency.as_deref(),
+            cents_bool,
+            separator.as_deref(),
+            adjective,
+            &kw,
+        )? {
+            (0, out) => Ok(out
+                .map(|o| presentation::apply_style(&o, style.as_deref(), to_final, lang))),
+            _ => Err(not_implemented()),
+        };
+    }
+
+    // ---- non-string input.
+    let to = if ordinal { "ordinal" } else { to };
+    if !CONVERTER_TYPES.contains(&to) {
+        return Err(not_implemented());
+    }
+
+    // integer modes with a plain int
+    if plain_int && RUST_TYPES.contains(&to) {
+        if let Some(kw) = extras_to_kwargs(kwargs, &["style", "precision"])? {
+            let n: BigInt = number.extract()?;
+            return match int_int_mode(l, to, &n, &kw) {
+                Ok(out) => {
+                    Ok(out.map(|o| presentation::apply_style(&o, style.as_deref(), to, lang)))
+                }
+                Err(N2WError::Fallback(_)) => Err(not_implemented()),
+                Err(e) => Err(map_err(e)),
+            };
+        }
+        // items None -> fall through
+    }
+
+    // float / Decimal, all four integer modes
+    if plain_num && RUST_TYPES.contains(&to) {
+        let finite = matches!(number.extract::<f64>(), Ok(f) if f.is_finite());
+        let items = extras_to_kwargs(
+            kwargs,
+            &[
+                "style",
+                "precision",
+                "currency",
+                "cents",
+                "separator",
+                "adjective",
+            ],
+        )?;
+        if let (true, Some(kw)) = (finite, items) {
+            let value = number.extract::<f64>()?;
+            let repr_str = pystr(number)?;
+            let prec = decimal_scale(&repr_str);
+            let decimal_str = if is_decimal {
+                repr_str.clone()
+            } else {
+                String::new()
+            };
+            let precision_override = get_precision(kwargs)?;
+            return match to_float_core(
+                l,
+                to,
+                value,
+                prec,
+                &decimal_str,
+                &repr_str,
+                precision_override,
+                &kw,
+            ) {
+                Ok(out) => {
+                    Ok(out.map(|o| presentation::apply_style(&o, style.as_deref(), to, lang)))
+                }
+                Err(N2WError::Fallback(_)) => Err(not_implemented()),
+                Err(e) => Err(map_err(e)),
+            };
+        }
+        // not finite or items None -> fall through
+    }
+
+    // currency
+    if to == "currency" && (intish || is_float || is_decimal) {
+        if let Some((cents_bool, drop)) = classify_cents(kwargs)? {
+            // cents='omit' on a float truncates to an int so no cents segment
+            // appears (the int path drops cents naturally).
+            let num_obj: Bound<'_, PyAny> = if drop && is_float {
+                py.import("builtins")?.getattr("int")?.call1((number,))?
+            } else {
+                number.clone()
+            };
+            if let Some(kw) = extras_to_kwargs(
+                kwargs,
+                &[
+                    "style",
+                    "precision",
+                    "currency",
+                    "cents",
+                    "separator",
+                    "adjective",
+                ],
+            )? {
+                let value_str = pystr(&num_obj)?;
+                let is_int_arg = num_obj.is_exact_instance_of::<PyInt>();
+                let is_float_arg = num_obj.is_instance_of::<PyFloat>();
+                let has_decimal_arg = is_float_arg || value_str.contains('.');
+                let currency = get_opt_str(kwargs, "currency")?;
+                let separator = get_opt_str(kwargs, "separator")?;
+                let adjective = get_opt_bool(kwargs, "adjective")?;
+                return match currency_core(
+                    l,
+                    &value_str,
+                    is_int_arg,
+                    has_decimal_arg,
+                    is_float_arg,
+                    currency.as_deref(),
+                    cents_bool,
+                    separator.as_deref(),
+                    adjective,
+                    &kw,
+                ) {
+                    Err(N2WError::Fallback(_)) => Err(not_implemented()),
+                    Err(e) => Err(map_err(e)),
+                    Ok(out) => Ok(out),
+                };
+            }
+            // items None -> fall through
+        }
+        // cents guard fail -> fall through
+    }
+
+    // cheque
+    if to == "cheque" && (intish || is_float || is_decimal) {
+        let value_str = pystr(number)?;
+        let currency = get_opt_str(kwargs, "currency")?;
+        return match cheque_core(l, &value_str, currency.as_deref()) {
+            Err(N2WError::Fallback(_)) => Err(not_implemented()),
+            Err(e) => Err(map_err(e)),
+            Ok(out) => Ok(out),
+        };
+    }
+
+    // fraction
+    if to == "fraction" {
+        return Err(map_err(fraction_probe(l)));
+    }
+
+    Err(not_implemented())
+}
+
+/// `num2words_sentence` — dispatches on `lang=None` (auto-detect) vs a fixed
+/// language, so the Python surface is a pass-through. `**kwargs` are accepted
+/// and ignored, matching the historic signature.
+#[pyfunction]
+#[pyo3(signature = (sentence, lang=Some("en".to_string()), to="cardinal", **_kwargs))]
+fn num2words_sentence(
+    sentence: &str,
+    lang: Option<String>,
+    to: &str,
+    _kwargs: Option<&Bound<'_, PyDict>>,
+) -> PyResult<String> {
+    match lang.as_deref() {
+        None => sentencepath::convert_auto(sentence, to).map_err(map_err),
+        Some(l) => sentencepath::convert(sentence, l, to).map_err(map_err),
+    }
 }
 
 /// `num2words2.grouping.group_digits`. The shim keeps the isinstance check
@@ -732,6 +1236,8 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(to_year_kw, m)?)?;
     m.add_function(wrap_pyfunction!(to_currency_kw, m)?)?;
     m.add_function(wrap_pyfunction!(from_string, m)?)?;
+    m.add_function(wrap_pyfunction!(num2words, m)?)?;
+    m.add_function(wrap_pyfunction!(num2words_sentence, m)?)?;
     m.add_function(wrap_pyfunction!(group_digits, m)?)?;
     m.add_function(wrap_pyfunction!(maxval, m)?)?;
     m.add_function(wrap_pyfunction!(sentence, m)?)?;

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from num2words2 import group_digits, grouping
+from num2words2 import group_digits
 
 
 # NOTE: these assertions were previously written as bare pytest-style
@@ -41,50 +41,3 @@ class GroupDigitsTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             group_digits(1.5)
 
-
-# The pure-Python grouping implementation is a real fallback used when the
-# num2words2._rust extension is unavailable (pure-Python / sdist installs).
-# Under the built CI wheel `group_digits` delegates to _rust, so the fallback
-# never runs there; exercise it here by temporarily unbinding the extension.
-# Assertions match the extension's output exactly (verified equal).
-class GroupDigitsPurePythonTest(unittest.TestCase):
-    def setUp(self):
-        self._saved_rust = grouping._RUST
-        grouping._RUST = None
-
-    def tearDown(self):
-        grouping._RUST = self._saved_rust
-
-    def test_western_grouping(self):
-        self.assertEqual(grouping.group_digits(1234567, locale="western"), "1,234,567")
-        self.assertEqual(grouping.group_digits(1000), "1,000")
-
-    def test_indian_grouping(self):
-        self.assertEqual(grouping.group_digits(100000, locale="indian"), "1,00,000")
-        self.assertEqual(
-            grouping.group_digits(12345678, locale="indian"), "1,23,45,678"
-        )
-        self.assertEqual(grouping.group_digits(999, locale="indian"), "999")
-
-    def test_chinese_grouping(self):
-        self.assertEqual(
-            grouping.group_digits(12345678, locale="chinese"), "1234,5678"
-        )
-
-    def test_negative(self):
-        self.assertEqual(
-            grouping.group_digits(-12345678, locale="indian"), "-1,23,45,678"
-        )
-
-    def test_zero(self):
-        self.assertEqual(grouping.group_digits(0, locale="indian"), "0")
-
-    def test_custom_separator(self):
-        self.assertEqual(
-            grouping.group_digits(100000, locale="indian", separator=" "),
-            "1 00 000",
-        )
-
-    def test_unknown_locale_raises(self):
-        with self.assertRaises(ValueError):
-            grouping.group_digits(100, locale="bogus")


### PR DESCRIPTION
Makes num2words2/ a **pure thin binder** like words2num2/ — **zero Python conversion/dispatch/presentation logic**.

Moved into **num2words2-core** (new pyo3-free `presentation.rs`) + the binder:
- `_normalize_lang` → `resolve_lang`; `_apply_style` → `apply_style` (style=terse/us); `_normalize_cents` → `normalize_cents`.
- kwarg marshalling → the binder; the full `num2words`/`num2words_sentence` dispatch → `#[pyfunction]`s.
- `grouping.py`: dropped the pure-Python fallback → pass-through to `_RUST.group_digits`.

`num2words2/__init__.py`: 300 → 77 lines; every function is `return _RUST.x(...)`. **num2words2-core 0.1.1** ([published](https://crates.io/crates/num2words2-core)).

## Verify (all green)
- cargo test 579; `cargo publish --dry-run` 0.1.1 OK.
- unittest `OK (skipped=1, expected failures=33)`, exit 0; E2E 16/16.
- coverage source 84% / tests 98%; flake8 0; isort clean. Output parity preserved.