### PR TITLE
ci: cross-compile the Intel macOS wheel on macos-14 (unstall Release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,10 @@ jobs:
         variant: [slim, full]
         platform:
           - { os: macos-14,       target: aarch64-apple-darwin }
-          - { os: macos-13,       target: x86_64-apple-darwin }
+          # Cross-compile the Intel wheel on the Apple-Silicon runner:
+          # GitHub's macos-13 (Intel) pool is deprecated and queues for hours,
+          # which stalled the whole Release (publish needs every build job).
+          - { os: macos-14,       target: x86_64-apple-darwin }
           - { os: ubuntu-latest,  target: x86_64-unknown-linux-gnu,  manylinux: auto }
           - { os: ubuntu-latest,  target: aarch64-unknown-linux-gnu, manylinux: auto }
           - { os: windows-latest, target: x86_64-pc-windows-msvc }


### PR DESCRIPTION
The Intel `macos-13` runner pool is deprecated and queues for hours, so the `x86_64-apple-darwin` wheel job never started. `publish-pypi` needs the whole build matrix, so the entire Release stalled — PyPI never got the new version and the AUR bump 404'd on the missing sdist. Cross-compile the Intel wheel on `macos-14` instead (maturin adds the target; no Intel host needed).