### PR TITLE
ci: build _rust extension in Scheduled Tests (fix ImportError)

### DIFF
--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -29,6 +29,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions
         pip install -r tests/requirements-test.txt
+        # Build the compiled `_rust` extension into the source tree so tox's
+        # `unittest discover` (run from the repo root) imports it instead of
+        # shadowing the package with the source dir, which has no _rust.
+        pip install -e .
 
     - name: Run tests with tox
       run: tox


### PR DESCRIPTION
Scheduled Tests failed on every OS/Python: `ImportError: cannot import name '_rust'`. Unlike ci.yml, the scheduled workflow never ran `pip install -e .`, so tox's `unittest discover` (from repo root) imported the source `num2words2/` — which has no compiled `_rust` — and every test module failed to import. Add the editable install to build the extension, matching ci.yml.